### PR TITLE
Implement `ff::PrimeField::to_repr` for `bn256::Fq2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "Sean Bowe <ewillbefull@gmail.com>",
   "Jack Grigg <jack@z.cash>",

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -555,7 +555,7 @@ impl ff::PrimeField for Fq2 {
     }
 
     fn to_repr(&self) -> Self::Repr {
-        unimplemented!();
+        Fq2Bytes(self.to_bytes())
     }
 
     fn is_odd(&self) -> Choice {


### PR DESCRIPTION
For EVM verifier to get bytes of G2 generator.