### PR TITLE
Make `Fq2`, `Fq6`, `Fq12` public

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This implementation is mostly ported from [matterlabs/pairing](https://github.co
 
 ## Bench
 
-None Assembly
+No assembly
 ```
 $ cargo test --profile bench test_field -- --nocapture
 ```
 
-Assembly
+Assembly (returns rust nightly)
 ```
 $ cargo test --profile bench test_field --features asm -- --nocapture
 ```

--- a/src/bn256/fq12.rs
+++ b/src/bn256/fq12.rs
@@ -320,7 +320,8 @@ impl Field for Fq12 {
 
 // non_residue^((modulus^i-1)/6) for i=0,...,11
 pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
-    // Fq2(u + 1)**(((q^0) - 1) / 6)
+    // Fq2(u + 9)**(((q^0) - 1) / 6)
+    // Fq points are represented in Montgomery form with R = 2^256
     Fq2 {
         c0: Fq([
             0xd35d438dc58f0d9d,
@@ -330,7 +331,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((q^1) - 1) / 6)
+    // Fq2(u + 9)**(((q^1) - 1) / 6)
     Fq2 {
         c0: Fq([
             0xaf9ba69633144907,
@@ -345,7 +346,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
             0x10a75716b3899551,
         ]),
     },
-    // Fq2(u + 1)**(((q^2) - 1) / 6)
+    // Fq2(u + 9)**(((q^2) - 1) / 6)
     Fq2 {
         c0: Fq([
             0xca8d800500fa1bf2,
@@ -355,7 +356,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((q^3) - 1) / 6)
+    // Fq2(u + 9)**(((q^3) - 1) / 6)
     Fq2 {
         c0: Fq([
             0x365316184e46d97d,
@@ -370,7 +371,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
             0x26684515eff054a6,
         ]),
     },
-    // Fq2(u + 1)**(((q^4) - 1) / 6)
+    // Fq2(u + 9)**(((q^4) - 1) / 6)
     Fq2 {
         c0: Fq([
             0x3350c88e13e80b9c,
@@ -380,7 +381,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((q^5) - 1) / 6)
+    // Fq2(u + 9)**(((q^5) - 1) / 6)
     Fq2 {
         c0: Fq([
             0x86b76f821b329076,
@@ -395,7 +396,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
             0x15c0edff3c66bf54,
         ]),
     },
-    // Fq2(u + 1)**(((q^6) - 1) / 6)
+    // Fq2(u + 9)**(((q^6) - 1) / 6)
     Fq2 {
         c0: Fq([
             0x68c3488912edefaa,
@@ -405,7 +406,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((q^7) - 1) / 6)
+    // Fq2(u + 9)**(((q^7) - 1) / 6)
     Fq2 {
         c0: Fq([
             0x8c84e580a568b440,
@@ -420,7 +421,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
             0x1fbcf75c2da80ad7,
         ]),
     },
-    // Fq2(u + 1)**(((q^8) - 1) / 6)
+    // Fq2(u + 9)**(((q^8) - 1) / 6)
     Fq2 {
         c0: Fq([
             0x71930c11d782e155,
@@ -430,7 +431,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((q^9) - 1) / 6)
+    // Fq2(u + 9)**(((q^9) - 1) / 6)
     Fq2 {
         c0: Fq([
             0x05cd75fe8a3623ca,
@@ -445,7 +446,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
             0x09fc095cf1414b83,
         ]),
     },
-    // Fq2(u + 1)**(((q^10) - 1) / 6)
+    // Fq2(u + 9)**(((q^10) - 1) / 6)
     Fq2 {
         c0: Fq([
             0x08cfc388c494f1ab,
@@ -455,7 +456,7 @@ pub const FROBENIUS_COEFF_FQ12_C1: [Fq2; 12] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((q^11) - 1) / 6)
+    // Fq2(u + 9)**(((q^11) - 1) / 6)
     Fq2 {
         c0: Fq([
             0xb5691c94bd4a6cd1,

--- a/src/bn256/mod.rs
+++ b/src/bn256/mod.rs
@@ -12,7 +12,9 @@ mod assembly;
 pub use curve::*;
 pub use engine::*;
 pub use fq::*;
-use fq2::*;
+pub use fq12::*;
+pub use fq2::*;
+pub use fq6::*;
 pub use fr::*;
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
It would be helpful for these structs to be public for use in other applications involving, e.g., pairing. (For example we use it to generate witnesses in some SNARKs.) If there is no security concern, then please expose these structs as public. 

I also fixed a few comments where the Frobenius coefficient comment was copied from BLS12-381 and the numbers are different for BN254. (The implementation is fine.) 