### PR TITLE
Add trait to serialize field and curve objects directly into raw bytes without Montgomery reduction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves"
-version = "0.2.1"
+version = "0.3.1"
 authors = [
   "Sean Bowe <ewillbefull@gmail.com>",
   "Jack Grigg <jack@z.cash>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ repository = "https://github.com/kilic/pairing"
 readme = "README.md"
 description = "Elliptic curve implementations and wrappers for halo2 library"
 
+[[bench]]
+name = "less_than"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
 rand_xorshift = "0.3"

--- a/benches/less_than.rs
+++ b/benches/less_than.rs
@@ -1,0 +1,64 @@
+#![allow(unused)]
+
+use criterion::BenchmarkId;
+
+/// Compute a - (b + borrow), returning the result and the new borrow.
+#[inline(always)]
+const fn sbb(a: u64, b: u64, borrow: u64) -> (u64, u64) {
+    let ret = (a as u128).wrapping_sub((b as u128) + ((borrow >> 63) as u128));
+    (ret as u64, (ret >> 64) as u64)
+}
+
+#[inline(always)]
+fn is_less_than(x: &[u64; 4], y: &[u64; 4]) -> bool {
+    match x[3].cmp(&y[3]) {
+        core::cmp::Ordering::Less => return true,
+        core::cmp::Ordering::Greater => return false,
+        _ => {}
+    }
+    match x[2].cmp(&y[2]) {
+        core::cmp::Ordering::Less => return true,
+        core::cmp::Ordering::Greater => return false,
+        _ => {}
+    }
+    match x[1].cmp(&y[1]) {
+        core::cmp::Ordering::Less => return true,
+        core::cmp::Ordering::Greater => return false,
+        _ => {}
+    }
+    x[0].lt(&y[0])
+}
+
+#[inline(always)]
+fn check_underflow(x: &[u64; 4], y: &[u64; 4]) -> bool {
+    let (_, borrow) = sbb(x[0], y[0], 0);
+    let (_, borrow) = sbb(x[1], y[1], borrow);
+    let (_, borrow) = sbb(x[2], y[2], borrow);
+    let (_, borrow) = sbb(x[3], y[3], borrow);
+    borrow >> 63 == 1
+}
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let x: [u64; 4] = [(); 4].map(|_| rand::random());
+    let y: [u64; 4] = [(); 4].map(|_| rand::random());
+
+    let mut group = c.benchmark_group("Big less than methods");
+
+    group.bench_with_input(
+        BenchmarkId::new("is_less_than", ""),
+        &(x, y),
+        |b, (x, y)| b.iter(|| is_less_than(x, y)),
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("check_underflow", ""),
+        &(x, y),
+        |b, (x, y)| b.iter(|| check_underflow(x, y)),
+    );
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -15,6 +15,13 @@ pub trait CurveAffineExt: pasta_curves::arithmetic::CurveAffine {
         bases: &[Self],
         base_positions: &[u32],
     );
+
+    /// Unlike the `Coordinates` trait, this just returns the raw affine coordinates without checking `is_on_curve`
+    fn into_coordinates(self) -> (Self::Base, Self::Base) {
+        // fallback implementation
+        let coordinates = self.coordinates().unwrap();
+        (*coordinates.x(), *coordinates.y())
+    }
 }
 
 pub(crate) fn sqrt_tonelli_shanks<F: ff::PrimeField, S: AsRef<[u64]>>(

--- a/src/bn256/assembly.rs
+++ b/src/bn256/assembly.rs
@@ -368,22 +368,11 @@ macro_rules! assembly_field {
         /// Lexicographic comparison of Montgomery forms.
         #[inline(always)]
         fn is_less_than(x: &[u64; 4], y: &[u64; 4]) -> bool {
-            match x[3].cmp(&y[3]) {
-                core::cmp::Ordering::Less => return true,
-                core::cmp::Ordering::Greater => return false,
-                _ => {}
-            }
-            match x[2].cmp(&y[2]) {
-                core::cmp::Ordering::Less => return true,
-                core::cmp::Ordering::Greater => return false,
-                _ => {}
-            }
-            match x[1].cmp(&y[1]) {
-                core::cmp::Ordering::Less => return true,
-                core::cmp::Ordering::Greater => return false,
-                _ => {}
-            }
-            x[0].lt(&y[0])
+            let (_, borrow) = sbb(x[0], y[0], 0);
+            let (_, borrow) = sbb(x[1], y[1], borrow);
+            let (_, borrow) = sbb(x[2], y[2], borrow);
+            let (_, borrow) = sbb(x[3], y[3], borrow);
+            borrow >> 63 == 1
         }
 
         impl $field {

--- a/src/bn256/assembly.rs
+++ b/src/bn256/assembly.rs
@@ -187,13 +187,6 @@ macro_rules! assembly_field {
                 }
             }
 
-            impl PartialEq for $field {
-                #[inline]
-                fn eq(&self, other: &Self) -> bool {
-                    self.0.eq(&other.0)
-                }
-            }
-
             impl core::cmp::Ord for $field {
                 fn cmp(&self, other: &Self) -> core::cmp::Ordering {
                     let left = self.to_repr();

--- a/src/bn256/assembly.rs
+++ b/src/bn256/assembly.rs
@@ -313,7 +313,7 @@ macro_rules! assembly_field {
 
         impl $crate::serde::SerdeObject for $field {
             fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
-                assert_eq!(bytes.len(), 32);
+                debug_assert_eq!(bytes.len(), 32);
                 let inner =
                     [0, 8, 16, 24].map(|i| u64::from_le_bytes(bytes[i..i + 8].try_into().unwrap()));
                 Self(inner)

--- a/src/bn256/assembly.rs
+++ b/src/bn256/assembly.rs
@@ -12,304 +12,379 @@ macro_rules! assembly_field {
         $r2:ident,
         $r3:ident
     ) => {
-            use std::arch::asm;
+        use std::arch::asm;
 
-            impl $field {
-                /// Returns zero, the additive identity.
-                #[inline]
-                pub const fn zero() -> $field {
-                    $field([0, 0, 0, 0])
-                }
-
-                /// Returns one, the multiplicative identity.
-                #[inline]
-                pub const fn one() -> $field {
-                    $r
-                }
-
-                fn from_u512(limbs: [u64; 8]) -> $field {
-                    // We reduce an arbitrary 512-bit number by decomposing it into two 256-bit digits
-                    // with the higher bits multiplied by 2^256. Thus, we perform two reductions
-                    //
-                    // 1. the lower bits are multiplied by R^2, as normal
-                    // 2. the upper bits are multiplied by R^2 * 2^256 = R^3
-                    //
-                    // and computing their sum in the field. It remains to see that arbitrary 256-bit
-                    // numbers can be placed into Montgomery form safely using the reduction. The
-                    // reduction works so long as the product is less than R=2^256 multiplied by
-                    // the modulus. This holds because for any `c` smaller than the modulus, we have
-                    // that (2^256 - 1)*c is an acceptable product for the reduction. Therefore, the
-                    // reduction always works so long as `c` is in the field; in this case it is either the
-                    // constant `R2` or `R3`.
-                    let d0 = $field([limbs[0], limbs[1], limbs[2], limbs[3]]);
-                    let d1 = $field([limbs[4], limbs[5], limbs[6], limbs[7]]);
-                    // Convert to Montgomery form
-                    d0 * $r2 + d1 * $r3
-                }
-
-                /// Converts from an integer represented in little endian
-                /// into its (congruent) `$field` representation.
-                pub const fn from_raw(val: [u64; 4]) -> Self {
-                    // Multiplication
-                    let (r0, carry) = mac(0, val[0], $r2.0[0], 0);
-                    let (r1, carry) = mac(0, val[0], $r2.0[1], carry);
-                    let (r2, carry) = mac(0, val[0], $r2.0[2], carry);
-                    let (r3, r4) = mac(0, val[0], $r2.0[3], carry);
-
-                    let (r1, carry) = mac(r1, val[1], $r2.0[0], 0);
-                    let (r2, carry) = mac(r2, val[1], $r2.0[1], carry);
-                    let (r3, carry) = mac(r3, val[1], $r2.0[2], carry);
-                    let (r4, r5) = mac(r4, val[1], $r2.0[3], carry);
-
-                    let (r2, carry) = mac(r2, val[2], $r2.0[0], 0);
-                    let (r3, carry) = mac(r3, val[2], $r2.0[1], carry);
-                    let (r4, carry) = mac(r4, val[2], $r2.0[2], carry);
-                    let (r5, r6) = mac(r5, val[2], $r2.0[3], carry);
-
-                    let (r3, carry) = mac(r3, val[3], $r2.0[0], 0);
-                    let (r4, carry) = mac(r4, val[3], $r2.0[1], carry);
-                    let (r5, carry) = mac(r5, val[3], $r2.0[2], carry);
-                    let (r6, r7) = mac(r6, val[3], $r2.0[3], carry);
-
-                    // Montgomery reduction (first part)
-                    let k = r0.wrapping_mul($inv);
-                    let (_, carry) = mac(r0, k, $modulus.0[0], 0);
-                    let (r1, carry) = mac(r1, k, $modulus.0[1], carry);
-                    let (r2, carry) = mac(r2, k, $modulus.0[2], carry);
-                    let (r3, carry) = mac(r3, k, $modulus.0[3], carry);
-                    let (r4, carry2) = adc(r4, 0, carry);
-
-                    let k = r1.wrapping_mul($inv);
-                    let (_, carry) = mac(r1, k, $modulus.0[0], 0);
-                    let (r2, carry) = mac(r2, k, $modulus.0[1], carry);
-                    let (r3, carry) = mac(r3, k, $modulus.0[2], carry);
-                    let (r4, carry) = mac(r4, k, $modulus.0[3], carry);
-                    let (r5, carry2) = adc(r5, carry2, carry);
-
-                    let k = r2.wrapping_mul($inv);
-                    let (_, carry) = mac(r2, k, $modulus.0[0], 0);
-                    let (r3, carry) = mac(r3, k, $modulus.0[1], carry);
-                    let (r4, carry) = mac(r4, k, $modulus.0[2], carry);
-                    let (r5, carry) = mac(r5, k, $modulus.0[3], carry);
-                    let (r6, carry2) = adc(r6, carry2, carry);
-
-                    let k = r3.wrapping_mul($inv);
-                    let (_, carry) = mac(r3, k, $modulus.0[0], 0);
-                    let (r4, carry) = mac(r4, k, $modulus.0[1], carry);
-                    let (r5, carry) = mac(r5, k, $modulus.0[2], carry);
-                    let (r6, carry) = mac(r6, k, $modulus.0[3], carry);
-                    let (r7, _) = adc(r7, carry2, carry);
-
-                    // Montgomery reduction (sub part)
-                    let (d0, borrow) = sbb(r4, $modulus.0[0], 0);
-                    let (d1, borrow) = sbb(r5, $modulus.0[1], borrow);
-                    let (d2, borrow) = sbb(r6, $modulus.0[2], borrow);
-                    let (d3, borrow) = sbb(r7, $modulus.0[3], borrow);
-
-                    let (d0, carry) = adc(d0, $modulus.0[0] & borrow, 0);
-                    let (d1, carry) = adc(d1, $modulus.0[1] & borrow, carry);
-                    let (d2, carry) = adc(d2, $modulus.0[2] & borrow, carry);
-                    let (d3, _) = adc(d3, $modulus.0[3] & borrow, carry);
-
-                    $field([d0, d1, d2, d3])
-                }
-
-                /// Attempts to convert a little-endian byte representation of
-                /// a scalar into a `Fr`, failing if the input is not canonical.
-                pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<$field> {
-                    <Self as ff::PrimeField>::from_repr(*bytes)
-                }
-
-                /// Converts an element of `Fr` into a byte representation in
-                /// little-endian byte order.
-                pub fn to_bytes(&self) -> [u8; 32] {
-                    <Self as ff::PrimeField>::to_repr(self)
-                }
+        impl $field {
+            /// Returns zero, the additive identity.
+            #[inline]
+            pub const fn zero() -> $field {
+                $field([0, 0, 0, 0])
             }
 
-            impl Group for $field {
-                type Scalar = Self;
-
-                fn group_zero() -> Self {
-                    Self::zero()
-                }
-                fn group_add(&mut self, rhs: &Self) {
-                    *self += *rhs;
-                }
-                fn group_sub(&mut self, rhs: &Self) {
-                    *self -= *rhs;
-                }
-                fn group_scale(&mut self, by: &Self::Scalar) {
-                    *self *= *by;
-                }
+            /// Returns one, the multiplicative identity.
+            #[inline]
+            pub const fn one() -> $field {
+                $r
             }
 
-            impl fmt::Debug for $field {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    let tmp = self.to_repr();
-                    write!(f, "0x")?;
-                    for &b in tmp.iter().rev() {
-                        write!(f, "{:02x}", b)?;
-                    }
-                    Ok(())
-                }
+            fn from_u512(limbs: [u64; 8]) -> $field {
+                // We reduce an arbitrary 512-bit number by decomposing it into two 256-bit digits
+                // with the higher bits multiplied by 2^256. Thus, we perform two reductions
+                //
+                // 1. the lower bits are multiplied by R^2, as normal
+                // 2. the upper bits are multiplied by R^2 * 2^256 = R^3
+                //
+                // and computing their sum in the field. It remains to see that arbitrary 256-bit
+                // numbers can be placed into Montgomery form safely using the reduction. The
+                // reduction works so long as the product is less than R=2^256 multiplied by
+                // the modulus. This holds because for any `c` smaller than the modulus, we have
+                // that (2^256 - 1)*c is an acceptable product for the reduction. Therefore, the
+                // reduction always works so long as `c` is in the field; in this case it is either the
+                // constant `R2` or `R3`.
+                let d0 = $field([limbs[0], limbs[1], limbs[2], limbs[3]]);
+                let d1 = $field([limbs[4], limbs[5], limbs[6], limbs[7]]);
+                // Convert to Montgomery form
+                d0 * $r2 + d1 * $r3
             }
 
-            impl Default for $field {
-                #[inline]
-                fn default() -> Self {
-                    Self::zero()
-                }
+            /// Converts from an integer represented in little endian
+            /// into its (congruent) `$field` representation.
+            pub const fn from_raw(val: [u64; 4]) -> Self {
+                // Multiplication
+                let (r0, carry) = mac(0, val[0], $r2.0[0], 0);
+                let (r1, carry) = mac(0, val[0], $r2.0[1], carry);
+                let (r2, carry) = mac(0, val[0], $r2.0[2], carry);
+                let (r3, r4) = mac(0, val[0], $r2.0[3], carry);
+
+                let (r1, carry) = mac(r1, val[1], $r2.0[0], 0);
+                let (r2, carry) = mac(r2, val[1], $r2.0[1], carry);
+                let (r3, carry) = mac(r3, val[1], $r2.0[2], carry);
+                let (r4, r5) = mac(r4, val[1], $r2.0[3], carry);
+
+                let (r2, carry) = mac(r2, val[2], $r2.0[0], 0);
+                let (r3, carry) = mac(r3, val[2], $r2.0[1], carry);
+                let (r4, carry) = mac(r4, val[2], $r2.0[2], carry);
+                let (r5, r6) = mac(r5, val[2], $r2.0[3], carry);
+
+                let (r3, carry) = mac(r3, val[3], $r2.0[0], 0);
+                let (r4, carry) = mac(r4, val[3], $r2.0[1], carry);
+                let (r5, carry) = mac(r5, val[3], $r2.0[2], carry);
+                let (r6, r7) = mac(r6, val[3], $r2.0[3], carry);
+
+                // Montgomery reduction (first part)
+                let k = r0.wrapping_mul($inv);
+                let (_, carry) = mac(r0, k, $modulus.0[0], 0);
+                let (r1, carry) = mac(r1, k, $modulus.0[1], carry);
+                let (r2, carry) = mac(r2, k, $modulus.0[2], carry);
+                let (r3, carry) = mac(r3, k, $modulus.0[3], carry);
+                let (r4, carry2) = adc(r4, 0, carry);
+
+                let k = r1.wrapping_mul($inv);
+                let (_, carry) = mac(r1, k, $modulus.0[0], 0);
+                let (r2, carry) = mac(r2, k, $modulus.0[1], carry);
+                let (r3, carry) = mac(r3, k, $modulus.0[2], carry);
+                let (r4, carry) = mac(r4, k, $modulus.0[3], carry);
+                let (r5, carry2) = adc(r5, carry2, carry);
+
+                let k = r2.wrapping_mul($inv);
+                let (_, carry) = mac(r2, k, $modulus.0[0], 0);
+                let (r3, carry) = mac(r3, k, $modulus.0[1], carry);
+                let (r4, carry) = mac(r4, k, $modulus.0[2], carry);
+                let (r5, carry) = mac(r5, k, $modulus.0[3], carry);
+                let (r6, carry2) = adc(r6, carry2, carry);
+
+                let k = r3.wrapping_mul($inv);
+                let (_, carry) = mac(r3, k, $modulus.0[0], 0);
+                let (r4, carry) = mac(r4, k, $modulus.0[1], carry);
+                let (r5, carry) = mac(r5, k, $modulus.0[2], carry);
+                let (r6, carry) = mac(r6, k, $modulus.0[3], carry);
+                let (r7, _) = adc(r7, carry2, carry);
+
+                // Montgomery reduction (sub part)
+                let (d0, borrow) = sbb(r4, $modulus.0[0], 0);
+                let (d1, borrow) = sbb(r5, $modulus.0[1], borrow);
+                let (d2, borrow) = sbb(r6, $modulus.0[2], borrow);
+                let (d3, borrow) = sbb(r7, $modulus.0[3], borrow);
+
+                let (d0, carry) = adc(d0, $modulus.0[0] & borrow, 0);
+                let (d1, carry) = adc(d1, $modulus.0[1] & borrow, carry);
+                let (d2, carry) = adc(d2, $modulus.0[2] & borrow, carry);
+                let (d3, _) = adc(d3, $modulus.0[3] & borrow, carry);
+
+                $field([d0, d1, d2, d3])
             }
 
-            impl From<bool> for $field {
-                fn from(bit: bool) -> $field {
-                    if bit {
-                        $field::one()
-                    } else {
-                        $field::zero()
-                    }
-                }
+            /// Attempts to convert a little-endian byte representation of
+            /// a scalar into a `Fr`, failing if the input is not canonical.
+            pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<$field> {
+                <Self as ff::PrimeField>::from_repr(*bytes)
             }
 
-            impl From<u64> for $field {
-                fn from(val: u64) -> $field {
-                    $field([val, 0, 0, 0]) * $r2
+            /// Converts an element of `Fr` into a byte representation in
+            /// little-endian byte order.
+            pub fn to_bytes(&self) -> [u8; 32] {
+                <Self as ff::PrimeField>::to_repr(self)
+            }
+        }
+
+        impl Group for $field {
+            type Scalar = Self;
+
+            fn group_zero() -> Self {
+                Self::zero()
+            }
+            fn group_add(&mut self, rhs: &Self) {
+                *self += *rhs;
+            }
+            fn group_sub(&mut self, rhs: &Self) {
+                *self -= *rhs;
+            }
+            fn group_scale(&mut self, by: &Self::Scalar) {
+                *self *= *by;
+            }
+        }
+
+        impl fmt::Debug for $field {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                let tmp = self.to_repr();
+                write!(f, "0x")?;
+                for &b in tmp.iter().rev() {
+                    write!(f, "{:02x}", b)?;
+                }
+                Ok(())
+            }
+        }
+
+        impl Default for $field {
+            #[inline]
+            fn default() -> Self {
+                Self::zero()
+            }
+        }
+
+        impl From<bool> for $field {
+            fn from(bit: bool) -> $field {
+                if bit {
+                    $field::one()
+                } else {
+                    $field::zero()
                 }
             }
+        }
 
-            impl ConstantTimeEq for $field {
-                fn ct_eq(&self, other: &Self) -> Choice {
-                    self.0[0].ct_eq(&other.0[0])
-                        & self.0[1].ct_eq(&other.0[1])
-                        & self.0[2].ct_eq(&other.0[2])
-                        & self.0[3].ct_eq(&other.0[3])
-                }
+        impl From<u64> for $field {
+            fn from(val: u64) -> $field {
+                $field([val, 0, 0, 0]) * $r2
+            }
+        }
+
+        impl ConstantTimeEq for $field {
+            fn ct_eq(&self, other: &Self) -> Choice {
+                self.0[0].ct_eq(&other.0[0])
+                    & self.0[1].ct_eq(&other.0[1])
+                    & self.0[2].ct_eq(&other.0[2])
+                    & self.0[3].ct_eq(&other.0[3])
+            }
+        }
+
+        impl core::cmp::Ord for $field {
+            fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+                let left = self.to_repr();
+                let right = other.to_repr();
+                left.iter()
+                    .zip(right.iter())
+                    .rev()
+                    .find_map(|(left_byte, right_byte)| match left_byte.cmp(right_byte) {
+                        core::cmp::Ordering::Equal => None,
+                        res => Some(res),
+                    })
+                    .unwrap_or(core::cmp::Ordering::Equal)
+            }
+        }
+
+        impl core::cmp::PartialOrd for $field {
+            fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl ConditionallySelectable for $field {
+            fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+                $field([
+                    u64::conditional_select(&a.0[0], &b.0[0], choice),
+                    u64::conditional_select(&a.0[1], &b.0[1], choice),
+                    u64::conditional_select(&a.0[2], &b.0[2], choice),
+                    u64::conditional_select(&a.0[3], &b.0[3], choice),
+                ])
+            }
+        }
+
+        impl<'a> Neg for &'a $field {
+            type Output = $field;
+
+            #[inline]
+            fn neg(self) -> $field {
+                self.neg()
+            }
+        }
+
+        impl Neg for $field {
+            type Output = $field;
+
+            #[inline]
+            fn neg(self) -> $field {
+                -&self
+            }
+        }
+
+        impl<'a, 'b> Sub<&'b $field> for &'a $field {
+            type Output = $field;
+
+            #[inline]
+            fn sub(self, rhs: &'b $field) -> $field {
+                self.sub(rhs)
+            }
+        }
+
+        impl<'a, 'b> Add<&'b $field> for &'a $field {
+            type Output = $field;
+
+            #[inline]
+            fn add(self, rhs: &'b $field) -> $field {
+                self.add(rhs)
+            }
+        }
+
+        impl<'a, 'b> Mul<&'b $field> for &'a $field {
+            type Output = $field;
+
+            #[inline]
+            fn mul(self, rhs: &'b $field) -> $field {
+                self.mul(rhs)
+            }
+        }
+
+        impl From<$field> for [u8; 32] {
+            fn from(value: $field) -> [u8; 32] {
+                value.to_repr()
+            }
+        }
+
+        impl<'a> From<&'a $field> for [u8; 32] {
+            fn from(value: &'a $field) -> [u8; 32] {
+                value.to_repr()
+            }
+        }
+
+        impl FieldExt for $field {
+            const MODULUS: &'static str = $modulus_str;
+            const TWO_INV: Self = $two_inv;
+            const ROOT_OF_UNITY_INV: Self = $root_of_unity_inv;
+            const DELTA: Self = $delta;
+            const ZETA: Self = $zeta;
+
+            fn from_u128(v: u128) -> Self {
+                $field::from_raw([v as u64, (v >> 64) as u64, 0, 0])
             }
 
-            impl core::cmp::Ord for $field {
-                fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-                    let left = self.to_repr();
-                    let right = other.to_repr();
-                    left.iter()
-                        .zip(right.iter())
-                        .rev()
-                        .find_map(|(left_byte, right_byte)| match left_byte.cmp(right_byte) {
-                            core::cmp::Ordering::Equal => None,
-                            res => Some(res),
-                        })
-                        .unwrap_or(core::cmp::Ordering::Equal)
-                }
+            /// Converts a 512-bit little endian integer into
+            /// a `$field` by reducing by the modulus.
+            fn from_bytes_wide(bytes: &[u8; 64]) -> $field {
+                $field::from_u512([
+                    u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+                    u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+                    u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+                    u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+                    u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
+                    u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
+                    u64::from_le_bytes(bytes[48..56].try_into().unwrap()),
+                    u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
+                ])
             }
 
-            impl core::cmp::PartialOrd for $field {
-                fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-                    Some(self.cmp(other))
-                }
+            fn get_lower_128(&self) -> u128 {
+                let tmp = $field::montgomery_reduce(&[
+                    self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0,
+                ]);
+
+                u128::from(tmp.0[0]) | (u128::from(tmp.0[1]) << 64)
             }
+        }
 
-            impl ConditionallySelectable for $field {
-                fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-                    $field([
-                        u64::conditional_select(&a.0[0], &b.0[0], choice),
-                        u64::conditional_select(&a.0[1], &b.0[1], choice),
-                        u64::conditional_select(&a.0[2], &b.0[2], choice),
-                        u64::conditional_select(&a.0[3], &b.0[3], choice),
-                    ])
-                }
+        impl $crate::serde::SerdeObject for $field {
+            fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
+                assert_eq!(bytes.len(), 32);
+                let inner =
+                    [0, 8, 16, 24].map(|i| u64::from_le_bytes(bytes[i..i + 8].try_into().unwrap()));
+                Self(inner)
             }
-
-            impl<'a> Neg for &'a $field {
-                type Output = $field;
-
-                #[inline]
-                fn neg(self) -> $field {
-                    self.neg()
+            fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != 32 {
+                    return None;
                 }
+                let elt = Self::from_raw_bytes_unchecked(bytes);
+                is_less_than(&elt.0, &$modulus.0).then(|| elt)
             }
-
-            impl Neg for $field {
-                type Output = $field;
-
-                #[inline]
-                fn neg(self) -> $field {
-                    -&self
+            fn to_raw_bytes(&self) -> Vec<u8> {
+                let mut res = Vec::with_capacity(32);
+                for limb in self.0.iter() {
+                    res.extend_from_slice(&limb.to_le_bytes());
                 }
+                res
             }
-
-            impl<'a, 'b> Sub<&'b $field> for &'a $field {
-                type Output = $field;
-
-                #[inline]
-                fn sub(self, rhs: &'b $field) -> $field {
-                    self.sub(rhs)
-                }
+            fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
+                let inner = [(); 4].map(|_| {
+                    let mut buf = [0; 8];
+                    reader.read_exact(&mut buf).unwrap();
+                    u64::from_le_bytes(buf)
+                });
+                Self(inner)
             }
-
-            impl<'a, 'b> Add<&'b $field> for &'a $field {
-                type Output = $field;
-
-                #[inline]
-                fn add(self, rhs: &'b $field) -> $field {
-                    self.add(rhs)
+            fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+                let mut inner = [0u64; 4];
+                for limb in inner.iter_mut() {
+                    let mut buf = [0; 8];
+                    reader.read_exact(&mut buf)?;
+                    *limb = u64::from_le_bytes(buf);
                 }
+                let elt = Self(inner);
+                is_less_than(&elt.0, &$modulus.0)
+                    .then(|| elt)
+                    .ok_or_else(|| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "input number is not less than field modulus",
+                        )
+                    })
             }
-
-            impl<'a, 'b> Mul<&'b $field> for &'a $field {
-                type Output = $field;
-
-                #[inline]
-                fn mul(self, rhs: &'b $field) -> $field {
-                    self.mul(rhs)
+            fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+                for limb in self.0.iter() {
+                    writer.write_all(&limb.to_le_bytes())?;
                 }
+                Ok(())
             }
+        }
 
-            impl From<$field> for [u8; 32] {
-                fn from(value: $field) -> [u8; 32] {
-                    value.to_repr()
-                }
+        /// Lexicographic comparison of Montgomery forms.
+        #[inline(always)]
+        fn is_less_than(x: &[u64; 4], y: &[u64; 4]) -> bool {
+            match x[3].cmp(&y[3]) {
+                core::cmp::Ordering::Less => return true,
+                core::cmp::Ordering::Greater => return false,
+                _ => {}
             }
-
-            impl<'a> From<&'a $field> for [u8; 32] {
-                fn from(value: &'a $field) -> [u8; 32] {
-                    value.to_repr()
-                }
+            match x[2].cmp(&y[2]) {
+                core::cmp::Ordering::Less => return true,
+                core::cmp::Ordering::Greater => return false,
+                _ => {}
             }
-
-            impl FieldExt for $field {
-                const MODULUS: &'static str = $modulus_str;
-                const TWO_INV: Self = $two_inv;
-                const ROOT_OF_UNITY_INV: Self = $root_of_unity_inv;
-                const DELTA: Self = $delta;
-                const ZETA: Self = $zeta;
-
-                fn from_u128(v: u128) -> Self {
-                    $field::from_raw([v as u64, (v >> 64) as u64, 0, 0])
-                }
-
-                /// Converts a 512-bit little endian integer into
-                /// a `$field` by reducing by the modulus.
-                fn from_bytes_wide(bytes: &[u8; 64]) -> $field {
-                    $field::from_u512([
-                        u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
-                        u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
-                        u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
-                        u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
-                        u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
-                        u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
-                        u64::from_le_bytes(bytes[48..56].try_into().unwrap()),
-                        u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
-                    ])
-                }
-
-                fn get_lower_128(&self) -> u128 {
-                    let tmp = $field::montgomery_reduce(&[
-                        self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0,
-                    ]);
-
-                    u128::from(tmp.0[0]) | (u128::from(tmp.0[1]) << 64)
-                }
+            match x[1].cmp(&y[1]) {
+                core::cmp::Ordering::Less => return true,
+                core::cmp::Ordering::Greater => return false,
+                _ => {}
             }
+            x[0].lt(&y[0])
+        }
 
         impl $field {
             /// Doubles this field element.

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -48,10 +48,18 @@ new_curve_impl!(
 
 impl CurveAffineExt for G1Affine {
     batch_add!();
+
+    fn into_coordinates(self) -> (Self::Base, Self::Base) {
+        (self.x, self.y)
+    }
 }
 
 impl CurveAffineExt for G2Affine {
     batch_add!();
+
+    fn into_coordinates(self) -> (Self::Base, Self::Base) {
+        (self.x, self.y)
+    }
 }
 
 const G1_GENERATOR_X: Fq = Fq::one();
@@ -284,6 +292,12 @@ mod tests {
         let exp_affine: G1Affine = expected.into();
 
         assert_eq!(res_affine, exp_affine);
+    }
+
+    #[test]
+    fn test_serialization() {
+        crate::tests::curve::random_serialization_test::<G1>();
+        crate::tests::curve::random_serialization_test::<G2>();
     }
 }
 

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -265,7 +265,6 @@ mod tests {
     #[test]
     fn test_endo_consistency() {
         let g = G1::generator();
-        dbg!(-ENDO_BETA);
         assert_eq!(g * (-ENDO_BETA), g.endo());
     }
 

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -265,6 +265,7 @@ mod tests {
     #[test]
     fn test_endo_consistency() {
         let g = G1::generator();
+        dbg!(-ENDO_BETA);
         assert_eq!(g * (-ENDO_BETA), g.endo());
     }
 

--- a/src/bn256/engine.rs
+++ b/src/bn256/engine.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::suspicious_arithmetic_impl)]
 use crate::bn256::curve::*;
 use crate::bn256::fq::*;
 use crate::bn256::fq12::*;
@@ -122,7 +123,6 @@ impl<'a, 'b> Add<&'b Gt> for &'a Gt {
     type Output = Gt;
 
     #[inline]
-    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, rhs: &'b Gt) -> Gt {
         Gt(self.0 * rhs.0)
     }
@@ -140,7 +140,6 @@ impl<'a, 'b> Sub<&'b Gt> for &'a Gt {
 impl<'a, 'b> Mul<&'b Fr> for &'a Gt {
     type Output = Gt;
 
-    #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, other: &'b Fr) -> Self::Output {
         let mut acc = Gt::identity();
 

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -351,4 +351,9 @@ mod test {
     fn test_field() {
         crate::tests::field::random_field_tests::<Fq>("fq".to_string());
     }
+
+    #[test]
+    fn test_serialization() {
+        crate::tests::field::random_serialization_test::<Fq>("fq".to_string());
+    }
 }

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -20,7 +20,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 // The internal representation of this type is four 64-bit unsigned
 // integers in little-endian order. `Fq` values are always in
 // Montgomery form; i.e., Fq(a) = aR mod q, with R = 2^256.
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Fq(pub(crate) [u64; 4]);
 
 /// Constant representing the modulus

--- a/src/bn256/fq12.rs
+++ b/src/bn256/fq12.rs
@@ -138,13 +138,13 @@ impl Fq12 {
     }
 
     pub fn mul(&self, other: &Self) -> Self {
-        let mut t = other.clone();
+        let mut t = *other;
         t.mul_assign(self);
         t
     }
 
     pub fn square(&self) -> Self {
-        let mut t = self.clone();
+        let mut t = *self;
         t.square_assign();
         t
     }
@@ -566,7 +566,7 @@ fn test_frobenius() {
     ]);
 
     for _ in 0..100 {
-        for i in 0..(14) {
+        for i in 0..14 {
             let mut a = Fq12::random(&mut rng);
             let mut b = a;
 

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// An element of Fq2, represented by c0 + c1 * u.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Fq2 {
     pub c0: Fq,
     pub c1: Fq,

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -573,7 +573,7 @@ impl ff::PrimeField for Fq2 {
 
 impl crate::serde::SerdeObject for Fq2 {
     fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
-        assert_eq!(bytes.len(), 64);
+        debug_assert_eq!(bytes.len(), 64);
         let [c0, c1] = [0, 32].map(|i| Fq::from_raw_bytes_unchecked(&bytes[i..i + 32]));
         Self { c0, c1 }
     }

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// An element of Fq2, represented by c0 + c1 * u.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Fq2 {
     pub c0: Fq,
     pub c1: Fq,

--- a/src/bn256/fq6.rs
+++ b/src/bn256/fq6.rs
@@ -207,13 +207,13 @@ impl Fq6 {
     }
 
     pub fn mul(&self, other: &Self) -> Self {
-        let mut t = other.clone();
+        let mut t = *other;
         t.mul_assign(self);
         t
     }
 
     pub fn square(&self) -> Self {
-        let mut t = self.clone();
+        let mut t = *self;
         t.square_assign();
         t
     }
@@ -678,7 +678,7 @@ fn test_frobenius() {
     ]);
 
     for _ in 0..100 {
-        for i in 0..(14) {
+        for i in 0..14 {
             let mut a = Fq6::random(&mut rng);
             let mut b = a;
 

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -358,4 +358,9 @@ mod test {
             ])
         );
     }
+
+    #[test]
+    fn test_serialization() {
+        crate::tests::field::random_serialization_test::<Fr>("fr".to_string());
+    }
 }

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -18,7 +18,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 // The internal representation of this type is four 64-bit unsigned
 // integers in little-endian order. `Fr` values are always in
 // Montgomery form; i.e., Fr(a) = aR mod r, with R = 2^256.
-#[derive(Clone, Copy, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Fr(pub(crate) [u64; 4]);
 
 /// Constant representing the modulus

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -288,9 +288,14 @@ impl SqrtRatio for Fr {
 
 #[cfg(test)]
 mod test {
+    use crate::serde::SerdeObject;
+
     use super::*;
+    use ark_std::{end_timer, start_timer};
     use ff::Field;
+    use rand::SeedableRng;
     use rand_core::OsRng;
+    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test_sqrt() {
@@ -362,5 +367,49 @@ mod test {
     #[test]
     fn test_serialization() {
         crate::tests::field::random_serialization_test::<Fr>("fr".to_string());
+    }
+
+    fn is_less_than(x: &[u64; 4], y: &[u64; 4]) -> bool {
+        match x[3].cmp(&y[3]) {
+            core::cmp::Ordering::Less => return true,
+            core::cmp::Ordering::Greater => return false,
+            _ => {}
+        }
+        match x[2].cmp(&y[2]) {
+            core::cmp::Ordering::Less => return true,
+            core::cmp::Ordering::Greater => return false,
+            _ => {}
+        }
+        match x[1].cmp(&y[1]) {
+            core::cmp::Ordering::Less => return true,
+            core::cmp::Ordering::Greater => return false,
+            _ => {}
+        }
+        x[0].lt(&y[0])
+    }
+
+    #[test]
+    fn test_serialization_check() {
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
+        let message = "serialization fr";
+        let start = start_timer!(|| message);
+        // failure check
+        for _ in 0..1000000 {
+            let rand_word = [(); 4].map(|_| rng.next_u64());
+            let a = Fr(rand_word);
+            let rand_bytes = a.to_raw_bytes();
+            match is_less_than(&rand_word, &MODULUS.0) {
+                false => {
+                    assert!(Fr::from_raw_bytes(&rand_bytes).is_none());
+                }
+                _ => {
+                    assert_eq!(Fr::from_raw_bytes(&rand_bytes), Some(a));
+                }
+            }
+        }
+        end_timer!(start);
     }
 }

--- a/src/bn256/mod.rs
+++ b/src/bn256/mod.rs
@@ -17,7 +17,7 @@ pub use fq2::*;
 pub use fq6::*;
 pub use fr::*;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum LegendreSymbol {
     Zero = 0,
     QuadraticResidue = 1,

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -36,10 +36,13 @@ macro_rules! batch_add {
                 #[cfg(all(feature = "prefetch", target_arch = "x86_64"))]
                 if i < num_points - 2 {
                     if LOAD_POINTS {
-                        crate::prefetch::<Self>(bases, base_positions[i + 2] as usize);
-                        crate::prefetch::<Self>(bases, base_positions[i + 3] as usize);
+                        $crate::prefetch::<Self>(bases, base_positions[i + 2] as usize);
+                        $crate::prefetch::<Self>(bases, base_positions[i + 3] as usize);
                     }
-                    crate::prefetch::<Self>(points, output_indices[(i >> 1) + 1] as usize - offset);
+                    $crate::prefetch::<Self>(
+                        points,
+                        output_indices[(i >> 1) + 1] as usize - offset,
+                    );
                 }
                 if LOAD_POINTS {
                     points[i] = get_point(base_positions[i]);
@@ -104,7 +107,10 @@ macro_rules! batch_add {
 
                 #[cfg(all(feature = "prefetch", target_arch = "x86_64"))]
                 if i > 0 {
-                    crate::prefetch::<Self>(points, output_indices[(i >> 1) - 1] as usize - offset);
+                    $crate::prefetch::<Self>(
+                        points,
+                        output_indices[(i >> 1) - 1] as usize - offset,
+                    );
                 }
 
                 if COMPLETE {
@@ -155,7 +161,7 @@ macro_rules! new_curve_impl {
             pub z: $base,
         }
 
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, PartialEq, Hash)]
         $($privacy)* struct $name_affine {
             pub x: $base,
             pub y: $base,
@@ -209,7 +215,7 @@ macro_rules! new_curve_impl {
                         };
 
 
-                        use crate::group::cofactor::CofactorGroup;
+                        use $crate::group::cofactor::CofactorGroup;
                         let p = p.to_curve();
                         return p.clear_cofactor().to_affine()
                     }
@@ -474,7 +480,7 @@ macro_rules! new_curve_impl {
             }
         }
 
-        impl crate::serde::SerdeObject for $name {
+        impl $crate::serde::SerdeObject for $name {
             fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
                 assert_eq!(bytes.len(), 3 * $base::size());
                 let [x, y, z] = [0, 1, 2]
@@ -590,12 +596,6 @@ macro_rules! new_curve_impl {
             }
         }
 
-        impl PartialEq for $name_affine {
-            fn eq(&self, other: &Self) -> bool {
-                self.ct_eq(other).into()
-            }
-        }
-
         impl cmp::Eq for $name_affine {}
 
         impl group::GroupEncoding for $name_affine {
@@ -647,7 +647,7 @@ macro_rules! new_curve_impl {
             }
         }
 
-        impl crate::serde::SerdeObject for $name_affine {
+        impl $crate::serde::SerdeObject for $name_affine {
             fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
                 assert_eq!(bytes.len(), 2 * $base::size());
                 let [x, y] =

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -474,6 +474,46 @@ macro_rules! new_curve_impl {
             }
         }
 
+        impl crate::serde::SerdeObject for $name {
+            fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
+                assert_eq!(bytes.len(), 3 * $base::size());
+                let [x, y, z] = [0, 1, 2]
+                    .map(|i| $base::from_raw_bytes_unchecked(&bytes[i * $base::size()..(i + 1) * $base::size()]));
+                Self { x, y, z }
+            }
+            fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != 3 * $base::size() {
+                    return None;
+                }
+                let [x, y, z] =
+                    [0, 1, 2].map(|i| $base::from_raw_bytes(&bytes[i * $base::size()..(i + 1) * $base::size()]));
+                x.zip(y).zip(z).and_then(|((x, y), z)| {
+                    let res = Self { x, y, z };
+                    // Check that the point is on the curve.
+                    bool::from(res.is_on_curve()).then(|| res)
+                })
+            }
+            fn to_raw_bytes(&self) -> Vec<u8> {
+                let mut res = Vec::with_capacity(3 * $base::size());
+                Self::write_raw(self, &mut res).unwrap();
+                res
+            }
+            fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
+                let [x, y, z] = [(); 3].map(|_| $base::read_raw_unchecked(reader));
+                Self { x, y, z }
+            }
+            fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+                let x = $base::read_raw(reader)?;
+                let y = $base::read_raw(reader)?;
+                let z = $base::read_raw(reader)?;
+                Ok(Self { x, y, z })
+            }
+            fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+                self.x.write_raw(writer)?;
+                self.y.write_raw(writer)?;
+                self.z.write_raw(writer)
+            }
+        }
 
         impl group::prime::PrimeGroup for $name {}
 
@@ -604,6 +644,44 @@ macro_rules! new_curve_impl {
                     xbytes[$compressed_size - 1] |= sign;
                     $name_compressed(xbytes)
                 }
+            }
+        }
+
+        impl crate::serde::SerdeObject for $name_affine {
+            fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
+                assert_eq!(bytes.len(), 2 * $base::size());
+                let [x, y] =
+                    [0, $base::size()].map(|i| $base::from_raw_bytes_unchecked(&bytes[i..i + $base::size()]));
+                Self { x, y }
+            }
+            fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
+                if bytes.len() != 2 * $base::size() {
+                    return None;
+                }
+                let [x, y] = [0, $base::size()].map(|i| $base::from_raw_bytes(&bytes[i..i + $base::size()]));
+                x.zip(y).and_then(|(x, y)| {
+                    let res = Self { x, y };
+                    // Check that the point is on the curve.
+                    bool::from(res.is_on_curve()).then(|| res)
+                })
+            }
+            fn to_raw_bytes(&self) -> Vec<u8> {
+                let mut res = Vec::with_capacity(2 * $base::size());
+                Self::write_raw(self, &mut res).unwrap();
+                res
+            }
+            fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
+                let [x, y] = [(); 2].map(|_| $base::read_raw_unchecked(reader));
+                Self { x, y }
+            }
+            fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+                let x = $base::read_raw(reader)?;
+                let y = $base::read_raw(reader)?;
+                Ok(Self { x, y })
+            }
+            fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+                self.x.write_raw(writer)?;
+                self.y.write_raw(writer)
             }
         }
 

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -482,7 +482,7 @@ macro_rules! new_curve_impl {
 
         impl $crate::serde::SerdeObject for $name {
             fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
-                assert_eq!(bytes.len(), 3 * $base::size());
+                debug_assert_eq!(bytes.len(), 3 * $base::size());
                 let [x, y, z] = [0, 1, 2]
                     .map(|i| $base::from_raw_bytes_unchecked(&bytes[i * $base::size()..(i + 1) * $base::size()]));
                 Self { x, y, z }
@@ -649,7 +649,7 @@ macro_rules! new_curve_impl {
 
         impl $crate::serde::SerdeObject for $name_affine {
             fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
-                assert_eq!(bytes.len(), 2 * $base::size());
+                debug_assert_eq!(bytes.len(), 2 * $base::size());
                 let [x, y] =
                     [0, $base::size()].map(|i| $base::from_raw_bytes_unchecked(&bytes[i..i + $base::size()]));
                 Self { x, y }

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -161,7 +161,7 @@ macro_rules! new_curve_impl {
             pub z: $base,
         }
 
-        #[derive(Copy, Clone, PartialEq, Hash)]
+        #[derive(Copy, Clone, PartialEq)]
         $($privacy)* struct $name_affine {
             pub x: $base,
             pub y: $base,

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -125,13 +125,6 @@ macro_rules! field_common {
             }
         }
 
-        impl PartialEq for $field {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                self.ct_eq(other).unwrap_u8() == 1
-            }
-        }
-
         impl core::cmp::Ord for $field {
             fn cmp(&self, other: &Self) -> core::cmp::Ordering {
                 let left = self.to_repr();

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -251,7 +251,7 @@ macro_rules! field_common {
 
         impl $crate::serde::SerdeObject for $field {
             fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
-                assert_eq!(bytes.len(), 32);
+                debug_assert_eq!(bytes.len(), 32);
                 let inner =
                     [0, 8, 16, 24].map(|i| u64::from_le_bytes(bytes[i..i + 8].try_into().unwrap()));
                 Self(inner)

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -416,22 +416,11 @@ macro_rules! field_arithmetic {
             /// Lexicographic comparison of Montgomery forms.
             #[inline(always)]
             fn is_less_than(x: &[u64; 4], y: &[u64; 4]) -> bool {
-                match x[3].cmp(&y[3]) {
-                    core::cmp::Ordering::Less => return true,
-                    core::cmp::Ordering::Greater => return false,
-                    _ => {}
-                }
-                match x[2].cmp(&y[2]) {
-                    core::cmp::Ordering::Less => return true,
-                    core::cmp::Ordering::Greater => return false,
-                    _ => {}
-                }
-                match x[1].cmp(&y[1]) {
-                    core::cmp::Ordering::Less => return true,
-                    core::cmp::Ordering::Greater => return false,
-                    _ => {}
-                }
-                x[0].lt(&y[0])
+                let (_, borrow) = sbb(x[0], y[0], 0);
+                let (_, borrow) = sbb(x[1], y[1], borrow);
+                let (_, borrow) = sbb(x[2], y[2], borrow);
+                let (_, borrow) = sbb(x[3], y[3], borrow);
+                borrow >> 63 == 1
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bn256;
 pub mod pairing;
 pub mod pasta;
 pub mod secp256k1;
+pub mod serde;
 
 #[macro_use]
 mod derive;

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -70,11 +70,20 @@ new_curve_impl!(
 
 impl CurveAffineExt for Secp256k1Affine {
     batch_add!();
+
+    fn into_coordinates(self) -> (Self::Base, Self::Base) {
+        (self.x, self.y)
+    }
 }
 
 #[test]
 fn test_curve() {
     crate::tests::curve::curve_tests::<Secp256k1>();
+}
+
+#[test]
+fn test_serialization() {
+    crate::tests::curve::random_serialization_test::<Secp256k1>();
 }
 
 #[test]

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -18,7 +18,7 @@ use crate::arithmetic::{adc, mac, sbb};
 // The internal representation of this type is four 64-bit unsigned
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Fp(a) = aR mod p, with R = 2^256.
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Fp(pub(crate) [u64; 4]);
 
 /// Constant representing the modulus

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -274,4 +274,9 @@ mod test {
     fn test_field() {
         crate::tests::field::random_field_tests::<Fp>("secp256k1 base".to_string());
     }
+
+    #[test]
+    fn test_serialization() {
+        crate::tests::field::random_serialization_test::<Fp>("secp256k1 base".to_string());
+    }
 }

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -317,4 +317,9 @@ mod test {
     fn test_field() {
         crate::tests::field::random_field_tests::<Fq>("secp256k1 scalar".to_string());
     }
+
+    #[test]
+    fn test_serialization() {
+        crate::tests::field::random_serialization_test::<Fq>("secp256k1 scalar".to_string());
+    }
 }

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -18,7 +18,7 @@ use pasta_curves::arithmetic::{FieldExt, Group, SqrtRatio};
 // The internal representation of this type is four 64-bit unsigned
 // integers in little-endian order. `Fq` values are always in
 // Montgomery form; i.e., Fq(a) = aR mod q, with R = 2^256.
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Fq(pub(crate) [u64; 4]);
 
 /// Constant representing the modulus

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,25 @@
+use std::io::{self, Read, Write};
+
+/// Trait for converting raw bytes to/from the internal representation of a type.
+/// For example, field elements are represented in Montgomery form and serialized/deserialized without Montgomery reduction.
+pub trait SerdeObject: Sized {
+    /// The purpose of unchecked functions is to read the internal memory representation
+    /// of a type from bytes as quickly as possible. No sanitization checks are performed
+    /// to ensure the bytes represent a valid object. As such this function should only be
+    /// used internally as an extension of machine memory. It should not be used to deserialize
+    /// externally provided data.
+    fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self;
+    fn from_raw_bytes(bytes: &[u8]) -> Option<Self>;
+
+    fn to_raw_bytes(&self) -> Vec<u8>;
+
+    /// The purpose of unchecked functions is to read the internal memory representation
+    /// of a type from disk as quickly as possible. No sanitization checks are performed
+    /// to ensure the bytes represent a valid object. This function should only be used
+    /// internally when some machine state cannot be kept in memory (e.g., between runs)
+    /// and needs to be reloaded as quickly as possible.
+    fn read_raw_unchecked<R: Read>(reader: &mut R) -> Self;
+    fn read_raw<R: Read>(reader: &mut R) -> io::Result<Self>;
+
+    fn write_raw<W: Write>(&self, writer: &mut W) -> io::Result<()>;
+}

--- a/src/tests/curve.rs
+++ b/src/tests/curve.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::eq_op)]
 use crate::group::GroupEncoding;
 use ff::Field;
 use group::prime::PrimeCurveAffine;

--- a/src/tests/curve.rs
+++ b/src/tests/curve.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::eq_op)]
-use crate::group::GroupEncoding;
+use crate::{group::GroupEncoding, serde::SerdeObject};
 use ff::Field;
 use group::prime::PrimeCurveAffine;
 use pasta_curves::arithmetic::{CurveAffine, CurveExt};
@@ -38,6 +38,33 @@ fn serdes<G: CurveExt>() {
         assert_eq!(projective_point, projective_point_rec_unchecked);
         assert_eq!(affine_point, affine_point_rec);
         assert_eq!(affine_point, affine_point_rec_unchecked);
+    }
+}
+
+pub fn random_serialization_test<G: CurveExt>()
+where
+    G: SerdeObject,
+    G::AffineExt: SerdeObject,
+{
+    for _ in 0..100 {
+        let projective_point = G::random(OsRng);
+        let affine_point: G::AffineExt = projective_point.into();
+
+        let projective_bytes = projective_point.to_raw_bytes();
+        let projective_point_rec = G::from_raw_bytes(&projective_bytes).unwrap();
+        assert_eq!(projective_point, projective_point_rec);
+        let mut buf = Vec::new();
+        projective_point.write_raw(&mut buf).unwrap();
+        let projective_point_rec = G::read_raw(&mut &buf[..]).unwrap();
+        assert_eq!(projective_point, projective_point_rec);
+
+        let affine_bytes = affine_point.to_raw_bytes();
+        let affine_point_rec = G::AffineExt::from_raw_bytes(&affine_bytes).unwrap();
+        assert_eq!(affine_point, affine_point_rec);
+        let mut buf = Vec::new();
+        affine_point.write_raw(&mut buf).unwrap();
+        let affine_point_rec = G::AffineExt::read_raw(&mut &buf[..]).unwrap();
+        assert_eq!(affine_point, affine_point_rec);
     }
 }
 

--- a/src/tests/field.rs
+++ b/src/tests/field.rs
@@ -3,6 +3,8 @@ use ff::Field;
 use rand::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
+use crate::serde::SerdeObject;
+
 pub fn random_field_tests<F: Field>(type_name: String) {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
@@ -204,6 +206,26 @@ fn random_expansion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
         t2.add_assign(&t5);
 
         assert_eq!(t0, t2);
+    }
+    end_timer!(start);
+}
+
+pub fn random_serialization_test<F: Field + SerdeObject>(type_name: String) {
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
+    let message = format!("serialization {}", type_name);
+    let start = start_timer!(|| message);
+    for _ in 0..1000000 {
+        let a = F::random(&mut rng);
+        let bytes = a.to_raw_bytes();
+        let b = F::from_raw_bytes(&bytes).unwrap();
+        assert_eq!(a, b);
+        let mut buf = Vec::new();
+        a.write_raw(&mut buf).unwrap();
+        let b = F::read_raw(&mut &buf[..]).unwrap();
+        assert_eq!(a, b);
     }
     end_timer!(start);
 }


### PR DESCRIPTION
Montgomery reduction dramatically slows down serialization speed for large halo2 proving keys.
Currently curves are serialized in compressed affine form. Deserializing involves a square root which is very expensive. For production purposes it is generally preferred to trade off more storage space for speed savings.