### PR TITLE
Switch to homogeneous coordinates + Add complete formulae

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ pasta_curves = "0.4.0"
 static_assertions = "1.1.0"
 rand = "0.8"
 rand_core = { version = "0.6", default-features = false }
-lazy_static = { version = "1.4.0"}
+lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 num-traits = "0.2"
 paste = "1.0.11"

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -397,7 +397,6 @@ macro_rules! new_curve_impl {
 
 
 
-
         impl $name {
             pub fn generator() -> Self {
                 let generator = $name_affine::generator();
@@ -414,7 +413,11 @@ macro_rules! new_curve_impl {
 
             #[inline]
             fn curve_constant_3b() -> $base {
-                $constant_b + $constant_b + $constant_b
+                lazy_static::lazy_static! {
+                        static ref CONST_3B: $base = $constant_b + $constant_b + $constant_b;
+                }
+                *CONST_3B
+
             }
         }
 


### PR DESCRIPTION
This PR contains two main changes:
 1. Complete formulas for addition and doubling. 
 2. Switch to homogeneous coordinates instead of jacobian coordinates.

The reference algorithms can be found here: https://eprint.iacr.org/2015/1060.pdf
The implementations for the complete formulas were directly taken from here: https://github.com/zkcrypto/bls12_381/blob/11617d9dd1b67cc6e102c08d507e5e5e11b9fbdf/src/g1.rs#L670

Close #15 