### PR TITLE
Port crate to pasta 0.5.0 and ff & group 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ ark-std = { version = "0.3" }
 
 [dependencies]
 subtle = "2.4"
-ff = "0.12.0"
-group = "0.12.0"
-pasta_curves = "0.4.0"
+ff = "0.13.0"
+group = "0.13.0"
+pasta_curves = "0.5.0"
 static_assertions = "1.1.0"
 rand = "0.8"
 rand_core = { version = "0.6", default-features = false }

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -42,36 +42,3 @@ pub(crate) const fn mac(a: u64, b: u64, c: u64, carry: u64) -> (u64, u64) {
     let ret = (a as u128) + ((b as u128) * (c as u128)) + (carry as u128);
     (ret as u64, (ret >> 64) as u64)
 }
-
-/// Compute a + (b * c), returning the result and the new carry over.
-#[inline(always)]
-pub(crate) const fn macx(a: u64, b: u64, c: u64) -> (u64, u64) {
-    let res = (a as u128) + ((b as u128) * (c as u128));
-    (res as u64, (res >> 64) as u64)
-}
-
-/// Compute a * b, returning the result.
-#[inline(always)]
-pub(crate) fn mul_512(a: [u64; 4], b: [u64; 4]) -> [u64; 8] {
-    let (r0, carry) = macx(0, a[0], b[0]);
-    let (r1, carry) = macx(carry, a[0], b[1]);
-    let (r2, carry) = macx(carry, a[0], b[2]);
-    let (r3, carry_out) = macx(carry, a[0], b[3]);
-
-    let (r1, carry) = macx(r1, a[1], b[0]);
-    let (r2, carry) = mac(r2, a[1], b[1], carry);
-    let (r3, carry) = mac(r3, a[1], b[2], carry);
-    let (r4, carry_out) = mac(carry_out, a[1], b[3], carry);
-
-    let (r2, carry) = macx(r2, a[2], b[0]);
-    let (r3, carry) = mac(r3, a[2], b[1], carry);
-    let (r4, carry) = mac(r4, a[2], b[2], carry);
-    let (r5, carry_out) = mac(carry_out, a[2], b[3], carry);
-
-    let (r3, carry) = macx(r3, a[3], b[0]);
-    let (r4, carry) = mac(r4, a[3], b[1], carry);
-    let (r5, carry) = mac(r5, a[3], b[2], carry);
-    let (r6, carry_out) = mac(carry_out, a[3], b[3], carry);
-
-    [r0, r1, r2, r3, r4, r5, r6, carry_out]
-}

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -24,50 +24,6 @@ pub trait CurveAffineExt: pasta_curves::arithmetic::CurveAffine {
     }
 }
 
-pub(crate) fn sqrt_tonelli_shanks<F: ff::PrimeField, S: AsRef<[u64]>>(
-    f: &F,
-    tm1d2: S,
-) -> CtOption<F> {
-    use subtle::ConstantTimeEq;
-
-    // w = self^((t - 1) // 2)
-    let w = f.pow_vartime(tm1d2);
-
-    let mut v = F::S;
-    let mut x = w * f;
-    let mut b = x * w;
-
-    // Initialize z as the 2^S root of unity.
-    let mut z = F::root_of_unity();
-
-    for max_v in (1..=F::S).rev() {
-        let mut k = 1;
-        let mut tmp = b.square();
-        let mut j_less_than_v: Choice = 1.into();
-
-        for j in 2..max_v {
-            let tmp_is_one = tmp.ct_eq(&F::one());
-            let squared = F::conditional_select(&tmp, &z, tmp_is_one).square();
-            tmp = F::conditional_select(&squared, &tmp, tmp_is_one);
-            let new_z = F::conditional_select(&z, &squared, tmp_is_one);
-            j_less_than_v &= !j.ct_eq(&v);
-            k = u32::conditional_select(&j, &k, tmp_is_one);
-            z = F::conditional_select(&z, &new_z, j_less_than_v);
-        }
-
-        let result = x * z;
-        x = F::conditional_select(&result, &x, b.ct_eq(&F::one()));
-        z = z.square();
-        b *= z;
-        v = k;
-    }
-
-    CtOption::new(
-        x,
-        (x * x).ct_eq(f), // Only return Some if it's the square root.
-    )
-}
-
 /// Compute a + b + carry, returning the result and the new carry over.
 #[inline(always)]
 pub(crate) const fn adc(a: u64, b: u64, carry: u64) -> (u64, u64) {

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -4,8 +4,6 @@
 //! This module is temporary, and the extension traits defined here are expected to be
 //! upstreamed into the `ff` and `group` crates after some refactoring.
 
-use subtle::{Choice, ConditionallySelectable, CtOption};
-
 pub trait CurveAffineExt: pasta_curves::arithmetic::CurveAffine {
     fn batch_add<const COMPLETE: bool, const LOAD_POINTS: bool>(
         points: &mut [Self],

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -9,7 +9,7 @@ use core::iter::Sum;
 use core::ops::{Add, Mul, Neg, Sub};
 use ff::{Field, PrimeField, WithSmallOrderMulGroup};
 use group::Curve;
-use group::{cofactor::CofactorGroup, prime::PrimeCurveAffine, Group, Group as _, GroupEncoding};
+use group::{cofactor::CofactorGroup, prime::PrimeCurveAffine, Group, GroupEncoding};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 

--- a/src/bn256/engine.rs
+++ b/src/bn256/engine.rs
@@ -89,7 +89,7 @@ impl PartialEq for Gt {
 impl Gt {
     /// Returns the group identity, which is $1$.
     pub fn identity() -> Gt {
-        Gt(Fq12::one())
+        Gt(Fq12::ONE)
     }
 
     /// Doubles this group element.
@@ -460,7 +460,7 @@ impl MillerLoopResult for Gt {
     fn final_exponentiation(&self) -> Gt {
         fn exp_by_x(f: &mut Fq12) {
             let x = BN_X;
-            let mut res = Fq12::one();
+            let mut res = Fq12::ONE;
             for i in (0..64).rev() {
                 res.cyclotomic_square();
                 if ((x >> i) & 1) == 1 {
@@ -582,7 +582,7 @@ pub fn multi_miller_loop(terms: &[(&G1Affine, &G2Prepared)]) -> Gt {
         f.mul_by_034(&c0, &c1, &coeffs.2);
     }
 
-    let mut f = Fq12::one();
+    let mut f = Fq12::ONE;
 
     for i in (1..SIX_U_PLUS_2_NAF.len()).rev() {
         if i != SIX_U_PLUS_2_NAF.len() - 1 {
@@ -787,12 +787,12 @@ pub fn engine_tests() {
         let d = G2Prepared::from(G2Affine::from(G2::random(&mut rng)));
 
         assert_eq!(
-            Fq12::one(),
+            Fq12::ONE,
             multi_miller_loop(&[(&z1, &b)]).final_exponentiation().0,
         );
 
         assert_eq!(
-            Fq12::one(),
+            Fq12::ONE,
             multi_miller_loop(&[(&a, &z2)]).final_exponentiation().0,
         );
 

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -69,9 +69,7 @@ pub const NEGATIVE_ONE: Fq = Fq([
 const MODULUS_STR: &str = "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47";
 
 /// Obtained with:
-/// ```
-/// sage: GF(0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47).primitive_element()
-/// ```
+/// `sage: GF(0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47).primitive_element()`
 const MULTIPLICATIVE_GENERATOR: Fq = Fq::from_raw([0x03, 0x0, 0x0, 0x0]);
 
 const TWO_INV: Fq = Fq::from_raw([

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -5,12 +5,10 @@ use crate::{field_arithmetic, field_specific};
 
 use super::LegendreSymbol;
 use crate::arithmetic::{adc, mac, sbb};
-use pasta_curves::arithmetic::{FieldExt, Group, SqrtRatio};
-
 use core::convert::TryInto;
 use core::fmt;
 use core::ops::{Add, Mul, Neg, Sub};
-use ff::PrimeField;
+use ff::{Field, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -70,12 +68,21 @@ pub const NEGATIVE_ONE: Fq = Fq([
 
 const MODULUS_STR: &str = "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47";
 
+/// Obtained with:
+/// ```
+/// sage: GF(0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47).primitive_element()
+/// ```
+const MULTIPLICATIVE_GENERATOR: Fq = Fq::from_raw([0x03, 0x0, 0x0, 0x0]);
+
 const TWO_INV: Fq = Fq::from_raw([
     0x9e10460b6c3e7ea4,
     0xcbc0b548b438e546,
     0xdc2822db40c0ac2e,
     0x183227397098d014,
 ]);
+
+// TODO: Can we simply put 0 here::
+const ROOT_OF_UNITY: Fq = Fq::zero();
 
 // Unused constant for base field
 const ROOT_OF_UNITY_INV: Fq = Fq::zero();
@@ -94,7 +101,7 @@ const ZETA: Fq = Fq::from_raw([
 use crate::{
     field_common, impl_add_binop_specify_output, impl_binops_additive,
     impl_binops_additive_specify_output, impl_binops_multiplicative,
-    impl_binops_multiplicative_mixed, impl_sub_binop_specify_output,
+    impl_binops_multiplicative_mixed, impl_sub_binop_specify_output, impl_sum_prod,
 };
 impl_binops_additive!(Fq, Fq);
 impl_binops_multiplicative!(Fq, Fq);
@@ -111,6 +118,7 @@ field_common!(
     R2,
     R3
 );
+impl_sum_prod!(Fq);
 #[cfg(not(feature = "asm"))]
 field_arithmetic!(Fq, MODULUS, INV, sparse);
 #[cfg(feature = "asm")]
@@ -142,19 +150,14 @@ impl Fq {
 }
 
 impl ff::Field for Fq {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+
     fn random(mut rng: impl RngCore) -> Self {
         let mut random_bytes = [0; 64];
         rng.fill_bytes(&mut random_bytes[..]);
 
-        Self::from_bytes_wide(&random_bytes)
-    }
-
-    fn zero() -> Self {
-        Self::zero()
-    }
-
-    fn one() -> Self {
-        Self::one()
+        Self::from_uniform_bytes(&random_bytes)
     }
 
     fn double(&self) -> Self {
@@ -178,6 +181,10 @@ impl ff::Field for Fq {
         CtOption::new(tmp, tmp.square().ct_eq(self))
     }
 
+    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+        ff::helpers::sqrt_ratio_generic(num, div)
+    }
+
     /// Computes the multiplicative inverse of this element,
     /// failing if the element is zero.
     fn invert(&self) -> CtOption<Self> {
@@ -197,7 +204,12 @@ impl ff::PrimeField for Fq {
 
     const NUM_BITS: u32 = 254;
     const CAPACITY: u32 = 253;
-
+    const MODULUS: &'static str = MODULUS_STR;
+    const MULTIPLICATIVE_GENERATOR: Self = MULTIPLICATIVE_GENERATOR;
+    const ROOT_OF_UNITY: Self = ROOT_OF_UNITY;
+    const ROOT_OF_UNITY_INV: Self = ROOT_OF_UNITY_INV;
+    const TWO_INV: Self = TWO_INV;
+    const DELTA: Self = DELTA;
     const S: u32 = 0;
 
     fn from_repr(repr: Self::Repr) -> CtOption<Self> {
@@ -244,24 +256,28 @@ impl ff::PrimeField for Fq {
     fn is_odd(&self) -> Choice {
         Choice::from(self.to_repr()[0] & 1)
     }
+}
 
-    fn multiplicative_generator() -> Self {
-        unimplemented!()
-    }
-
-    fn root_of_unity() -> Self {
-        unimplemented!()
+impl FromUniformBytes<64> for Fq {
+    /// Converts a 512-bit little endian integer into
+    /// an `Fq` by reducing by the modulus.
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+        Self::from_u512([
+            u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+            u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+            u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+            u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
+            u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
+            u64::from_le_bytes(bytes[48..56].try_into().unwrap()),
+            u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
+        ])
     }
 }
 
-impl SqrtRatio for Fq {
-    const T_MINUS1_OVER2: [u64; 4] = [0, 0, 0, 0];
-
-    fn get_lower_32(&self) -> u32 {
-        let tmp = Fq::montgomery_reduce(&[self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0]);
-
-        tmp.0[0] as u32
-    }
+// TODO: Check the correctness of this 3!!
+impl WithSmallOrderMulGroup<3> for Fq {
+    const ZETA: Self = ZETA;
 }
 
 #[cfg(test)]

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -275,7 +275,6 @@ impl FromUniformBytes<64> for Fq {
     }
 }
 
-// TODO: Check the correctness of this 3!!
 impl WithSmallOrderMulGroup<3> for Fq {
     const ZETA: Self = ZETA;
 }

--- a/src/bn256/fq12.rs
+++ b/src/bn256/fq12.rs
@@ -320,7 +320,7 @@ impl Field for Fq12 {
         unimplemented!()
     }
 
-    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+    fn sqrt_ratio(_num: &Self, _div: &Self) -> (Choice, Self) {
         unimplemented!()
     }
 

--- a/src/bn256/fq12.rs
+++ b/src/bn256/fq12.rs
@@ -75,11 +75,29 @@ impl<'a, 'b> Mul<&'b Fq12> for &'a Fq12 {
 use crate::{
     impl_add_binop_specify_output, impl_binops_additive, impl_binops_additive_specify_output,
     impl_binops_multiplicative, impl_binops_multiplicative_mixed, impl_sub_binop_specify_output,
+    impl_sum_prod,
 };
 impl_binops_additive!(Fq12, Fq12);
 impl_binops_multiplicative!(Fq12, Fq12);
+impl_sum_prod!(Fq12);
 
 impl Fq12 {
+    #[inline]
+    pub const fn zero() -> Self {
+        Fq12 {
+            c0: Fq6::ZERO,
+            c1: Fq6::ZERO,
+        }
+    }
+
+    #[inline]
+    pub const fn one() -> Self {
+        Fq12 {
+            c0: Fq6::ONE,
+            c1: Fq6::ZERO,
+        }
+    }
+
     pub fn mul_assign(&mut self, other: &Self) {
         let t0 = self.c0 * other.c0;
         let mut t1 = self.c1 * other.c1;
@@ -276,24 +294,13 @@ impl Fq12 {
 }
 
 impl Field for Fq12 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+
     fn random(mut rng: impl RngCore) -> Self {
         Fq12 {
             c0: Fq6::random(&mut rng),
             c1: Fq6::random(&mut rng),
-        }
-    }
-
-    fn zero() -> Self {
-        Fq12 {
-            c0: Fq6::zero(),
-            c1: Fq6::zero(),
-        }
-    }
-
-    fn one() -> Self {
-        Fq12 {
-            c0: Fq6::one(),
-            c1: Fq6::zero(),
         }
     }
 
@@ -310,6 +317,10 @@ impl Field for Fq12 {
     }
 
     fn sqrt(&self) -> CtOption<Self> {
+        unimplemented!()
+    }
+
+    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
         unimplemented!()
     }
 

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -403,7 +403,7 @@ impl Field for Fq2 {
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
-        todo!()
+        ff::helpers::sqrt_ratio_generic(num, div)
     }
 
     fn invert(&self) -> CtOption<Self> {

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -2,8 +2,7 @@ use super::fq::{Fq, NEGATIVE_ONE};
 use super::LegendreSymbol;
 use core::convert::TryInto;
 use core::ops::{Add, Mul, Neg, Sub};
-use ff::Field;
-use pasta_curves::arithmetic::{FieldExt, Group, SqrtRatio};
+use ff::{Field, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rand::RngCore;
 use std::cmp::Ordering;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -52,7 +51,7 @@ impl ConstantTimeEq for Fq2 {
 impl Default for Fq2 {
     #[inline]
     fn default() -> Self {
-        Self::zero()
+        Self::ZERO
     }
 }
 
@@ -116,11 +115,29 @@ impl<'a, 'b> Mul<&'b Fq2> for &'a Fq2 {
 use crate::{
     impl_add_binop_specify_output, impl_binops_additive, impl_binops_additive_specify_output,
     impl_binops_multiplicative, impl_binops_multiplicative_mixed, impl_sub_binop_specify_output,
+    impl_sum_prod,
 };
 impl_binops_additive!(Fq2, Fq2);
 impl_binops_multiplicative!(Fq2, Fq2);
+impl_sum_prod!(Fq2);
 
 impl Fq2 {
+    #[inline]
+    pub const fn zero() -> Fq2 {
+        Fq2 {
+            c0: Fq::zero(),
+            c1: Fq::zero(),
+        }
+    }
+
+    #[inline]
+    pub const fn one() -> Fq2 {
+        Fq2 {
+            c0: Fq::one(),
+            c1: Fq::zero(),
+        }
+    }
+
     pub const fn new(c0: Fq, c1: Fq) -> Self {
         Fq2 { c0, c1 }
     }
@@ -307,24 +324,13 @@ impl Fq2 {
 }
 
 impl Field for Fq2 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+
     fn random(mut rng: impl RngCore) -> Self {
         Fq2 {
             c0: Fq::random(&mut rng),
             c1: Fq::random(&mut rng),
-        }
-    }
-
-    fn zero() -> Self {
-        Fq2 {
-            c0: Fq::zero(),
-            c1: Fq::zero(),
-        }
-    }
-
-    fn one() -> Self {
-        Fq2 {
-            c0: Fq::one(),
-            c1: Fq::zero(),
         }
     }
 
@@ -344,7 +350,7 @@ impl Field for Fq2 {
         // Algorithm 9, https://eprint.iacr.org/2012/685.pdf
 
         if self.is_zero().into() {
-            CtOption::new(Self::zero(), Choice::from(1))
+            CtOption::new(Self::ZERO, Choice::from(1))
         } else {
             // a1 = self^((q - 3) / 4)
             // 0xc19139cb84c680a6e14116da060561765e05aa45a1c72a34f082305b61f3f51
@@ -379,7 +385,7 @@ impl Field for Fq2 {
                         c1: Fq::one(),
                     });
                 } else {
-                    alpha += &Fq2::one();
+                    alpha += &Fq2::ONE;
                     // alpha = alpha^((q - 1) / 2)
                     // 0x183227397098d014dc2822db40c0ac2ecbc0b548b438e5469e10460b6c3e7ea3
                     let u: [u64; 4] = [
@@ -396,6 +402,10 @@ impl Field for Fq2 {
         }
     }
 
+    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+        todo!()
+    }
+
     fn invert(&self) -> CtOption<Self> {
         self.invert()
     }
@@ -404,9 +414,9 @@ impl Field for Fq2 {
 impl From<bool> for Fq2 {
     fn from(bit: bool) -> Fq2 {
         if bit {
-            Fq2::one()
+            Fq2::ONE
         } else {
-            Fq2::zero()
+            Fq2::ZERO
         }
     }
 }
@@ -420,10 +430,20 @@ impl From<u64> for Fq2 {
     }
 }
 
-impl FieldExt for Fq2 {
+impl PrimeField for Fq2 {
+    type Repr = Fq2Bytes;
+
     const MODULUS: &'static str =
         "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47";
-
+    const MULTIPLICATIVE_GENERATOR: Self = Fq2 {
+        c0: Fq::from_raw([0x03, 0x0, 0x0, 0x0]),
+        c1: Fq::ZERO,
+    };
+    const NUM_BITS: u32 = 254;
+    const CAPACITY: u32 = 253;
+    const S: u32 = 0;
+    // TODO: Check that we can just 0 this and forget.
+    const ROOT_OF_UNITY: Self = Fq2::zero();
     const ROOT_OF_UNITY_INV: Self = Fq2 {
         c0: Fq::zero(),
         c1: Fq::zero(),
@@ -441,83 +461,28 @@ impl FieldExt for Fq2 {
         ]),
         c1: Fq([0, 0, 0, 0]),
     };
-    const ZETA: Self = Fq2 {
-        c0: Fq::zero(),
-        c1: Fq::zero(),
-    };
 
-    /// Converts a 512-bit little endian integer into
-    /// a `Fq` by reducing by the modulus.
-    fn from_bytes_wide(bytes: &[u8; 64]) -> Self {
-        Self::new(Fq::from_bytes_wide(bytes), Fq::zero())
+    fn from_repr(repr: Self::Repr) -> CtOption<Self> {
+        let c0 = Fq::from_bytes(&repr.0[..32].try_into().unwrap());
+        let c1 = Fq::from_bytes(&repr.0[32..].try_into().unwrap());
+        // Disallow overflow representation
+        CtOption::new(Fq2::new(c0.unwrap(), c1.unwrap()), Choice::from(1))
     }
 
-    fn from_u128(v: u128) -> Self {
-        Fq2 {
-            c0: Fq::from_raw([v as u64, (v >> 64) as u64, 0, 0]),
-            c1: Fq::zero(),
-        }
+    fn to_repr(&self) -> Self::Repr {
+        Fq2Bytes(self.to_bytes())
     }
 
-    fn get_lower_128(&self) -> u128 {
-        self.c0.get_lower_128()
-    }
-
-    // /// Writes this element in its normalized, little endian form into a buffer.
-    // fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
-    //     let compressed = self.to_bytes();
-    //     writer.write_all(&compressed[..])
-    // }
-
-    // /// Reads a normalized, little endian represented field element from a
-    // /// buffer.
-    // fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
-    //     let mut compressed = [0u8; 64];
-    //     reader.read_exact(&mut compressed[..])?;
-    //     Option::from(Self::from_bytes(&compressed))
-    //         .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "invalid point encoding in proof"))
-    // }
-}
-
-impl SqrtRatio for Fq2 {
-    const T_MINUS1_OVER2: [u64; 4] = [0, 0, 0, 0];
-
-    fn pow_by_t_minus1_over2(&self) -> Self {
-        unimplemented!();
-    }
-
-    fn get_lower_32(&self) -> u32 {
-        unimplemented!();
-    }
-
-    #[cfg(feature = "sqrt-table")]
-    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
-        unimplemented!();
-    }
-
-    #[cfg(feature = "sqrt-table")]
-    fn sqrt_alt(&self) -> (Choice, Self) {
-        unimplemented!();
+    fn is_odd(&self) -> Choice {
+        Choice::from(self.to_repr().as_ref()[0] & 1)
     }
 }
 
-impl Group for Fq2 {
-    type Scalar = Fq2;
-
-    fn group_zero() -> Self {
-        Self::zero()
-    }
-    fn group_add(&mut self, rhs: &Self) {
-        *self += *rhs;
-    }
-    fn group_sub(&mut self, rhs: &Self) {
-        *self -= *rhs;
-    }
-    fn group_scale(&mut self, by: &Self::Scalar) {
-        *self *= *by;
+impl FromUniformBytes<64> for Fq2 {
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+        Self::new(Fq::from_uniform_bytes(bytes), Fq::zero())
     }
 }
-
 #[derive(Clone, Copy, Debug)]
 pub struct Fq2Bytes([u8; 64]);
 
@@ -536,38 +501,6 @@ impl AsMut<[u8]> for Fq2Bytes {
 impl AsRef<[u8]> for Fq2Bytes {
     fn as_ref(&self) -> &[u8] {
         &self.0
-    }
-}
-
-impl ff::PrimeField for Fq2 {
-    type Repr = Fq2Bytes;
-
-    const NUM_BITS: u32 = 254;
-    const CAPACITY: u32 = 253;
-
-    const S: u32 = 0;
-
-    fn from_repr(repr: Self::Repr) -> CtOption<Self> {
-        let c0 = Fq::from_bytes(&repr.0[..32].try_into().unwrap());
-        let c1 = Fq::from_bytes(&repr.0[32..].try_into().unwrap());
-        // Disallow overflow representation
-        CtOption::new(Fq2::new(c0.unwrap(), c1.unwrap()), Choice::from(1))
-    }
-
-    fn to_repr(&self) -> Self::Repr {
-        Fq2Bytes(self.to_bytes())
-    }
-
-    fn is_odd(&self) -> Choice {
-        Choice::from(self.to_repr().as_ref()[0] & 1)
-    }
-
-    fn multiplicative_generator() -> Self {
-        unimplemented!()
-    }
-
-    fn root_of_unity() -> Self {
-        unimplemented!()
     }
 }
 
@@ -604,6 +537,14 @@ impl crate::serde::SerdeObject for Fq2 {
         self.c0.write_raw(writer)?;
         self.c1.write_raw(writer)
     }
+}
+
+// TODO: Is it ok to leave it like this????
+impl WithSmallOrderMulGroup<3> for Fq2 {
+    const ZETA: Self = Fq2 {
+        c0: Fq::zero(),
+        c1: Fq::zero(),
+    };
 }
 
 pub const FROBENIUS_COEFF_FQ2_C1: [Fq; 2] = [
@@ -673,17 +614,17 @@ fn test_fq2_basics() {
             c0: Fq::zero(),
             c1: Fq::zero(),
         },
-        Fq2::zero()
+        Fq2::ZERO
     );
     assert_eq!(
         Fq2 {
             c0: Fq::one(),
             c1: Fq::zero(),
         },
-        Fq2::one()
+        Fq2::ONE
     );
-    assert_eq!(Fq2::zero().is_zero().unwrap_u8(), 1);
-    assert_eq!(Fq2::one().is_zero().unwrap_u8(), 0);
+    assert_eq!(Fq2::ZERO.is_zero().unwrap_u8(), 1);
+    assert_eq!(Fq2::ONE.is_zero().unwrap_u8(), 0);
     assert_eq!(
         Fq2 {
             c0: Fq::zero(),
@@ -748,9 +689,9 @@ fn test_fq2_mul_nonresidue() {
 
 #[test]
 fn test_fq2_legendre() {
-    assert_eq!(LegendreSymbol::Zero, Fq2::zero().legendre());
+    assert_eq!(LegendreSymbol::Zero, Fq2::ZERO.legendre());
     // i^2 = -1
-    let mut m1 = Fq2::one();
+    let mut m1 = Fq2::ONE;
     m1 = m1.neg();
     assert_eq!(LegendreSymbol::QuadraticResidue, m1.legendre());
     m1.mul_by_nonresidue();
@@ -784,7 +725,7 @@ pub fn test_sqrt() {
         assert!(a == b || a == negb);
     }
 
-    let mut c = Fq2::one();
+    let mut c = Fq2::ONE;
     for _ in 0..10000 {
         let mut b = c;
         b.square_assign();
@@ -798,7 +739,7 @@ pub fn test_sqrt() {
 
         assert_eq!(b, c);
 
-        c += &Fq2::one();
+        c += &Fq2::ONE;
     }
 }
 

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -539,10 +539,15 @@ impl crate::serde::SerdeObject for Fq2 {
     }
 }
 
-// TODO: Is it ok to leave it like this????
 impl WithSmallOrderMulGroup<3> for Fq2 {
+    // Fq::ZETA ^2
     const ZETA: Self = Fq2 {
-        c0: Fq::zero(),
+        c0: Fq::from_raw([
+            0xe4bd44e5607cfd48,
+            0xc28f069fbb966e3d,
+            0x5e6dd9e7e0acccb0,
+            0x30644e72e131a029,
+        ]),
         c1: Fq::zero(),
     };
 }

--- a/src/bn256/fq6.rs
+++ b/src/bn256/fq6.rs
@@ -76,11 +76,31 @@ impl<'a, 'b> Mul<&'b Fq6> for &'a Fq6 {
 use crate::{
     impl_add_binop_specify_output, impl_binops_additive, impl_binops_additive_specify_output,
     impl_binops_multiplicative, impl_binops_multiplicative_mixed, impl_sub_binop_specify_output,
+    impl_sum_prod,
 };
 impl_binops_additive!(Fq6, Fq6);
 impl_binops_multiplicative!(Fq6, Fq6);
+impl_sum_prod!(Fq6);
 
 impl Fq6 {
+    #[inline]
+    pub const fn zero() -> Self {
+        Fq6 {
+            c0: Fq2::ZERO,
+            c1: Fq2::ZERO,
+            c2: Fq2::ZERO,
+        }
+    }
+
+    #[inline]
+    pub const fn one() -> Self {
+        Fq6 {
+            c0: Fq2::ONE,
+            c1: Fq2::ZERO,
+            c2: Fq2::ZERO,
+        }
+    }
+
     pub fn mul_assign(&mut self, other: &Self) {
         let mut a_a = self.c0;
         let mut b_b = self.c1;
@@ -376,27 +396,14 @@ impl Fq6 {
 }
 
 impl Field for Fq6 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+
     fn random(mut rng: impl RngCore) -> Self {
         Fq6 {
             c0: Fq2::random(&mut rng),
             c1: Fq2::random(&mut rng),
             c2: Fq2::random(&mut rng),
-        }
-    }
-
-    fn zero() -> Self {
-        Fq6 {
-            c0: Fq2::zero(),
-            c1: Fq2::zero(),
-            c2: Fq2::zero(),
-        }
-    }
-
-    fn one() -> Self {
-        Fq6 {
-            c0: Fq2::one(),
-            c1: Fq2::zero(),
-            c2: Fq2::zero(),
         }
     }
 
@@ -413,6 +420,10 @@ impl Field for Fq6 {
     }
 
     fn sqrt(&self) -> CtOption<Self> {
+        unimplemented!()
+    }
+
+    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
         unimplemented!()
     }
 

--- a/src/bn256/fq6.rs
+++ b/src/bn256/fq6.rs
@@ -423,7 +423,7 @@ impl Field for Fq6 {
         unimplemented!()
     }
 
-    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+    fn sqrt_ratio(_num: &Self, _div: &Self) -> (Choice, Self) {
         unimplemented!()
     }
 

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -369,8 +369,8 @@ mod test {
             0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
             0xbc, 0xe5,
         ]);
-        let message = "serialization fr";
-        let start = start_timer!(|| message);
+        let _message = "serialization fr";
+        let start = start_timer!(|| _message);
         // failure check
         for _ in 0..1000000 {
             let rand_word = [(); 4].map(|_| rng.next_u64());

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -107,10 +107,10 @@ const DELTA: Fr = Fr::from_raw([
 
 /// `ZETA^3 = 1 mod r` where `ZETA^2 != 1 mod r`
 const ZETA: Fr = Fr::from_raw([
-    0xb8ca0b2d36636f23,
-    0xcc37a73fec2bc5e9,
-    0x048b6e193fd84104,
-    0x30644e72e131a029,
+    0x8b17ea66b99c90dd,
+    0x5bfc41088d8daaa7,
+    0xb3c4d79d41a91758,
+    0x00,
 ]);
 
 use crate::{

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -269,7 +269,6 @@ impl FromUniformBytes<64> for Fr {
     }
 }
 
-// TODO: Check the correctness of this 3!!
 impl WithSmallOrderMulGroup<3> for Fr {
     const ZETA: Self = ZETA;
 }

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -7,8 +7,7 @@ use crate::arithmetic::{adc, mac, sbb};
 use core::convert::TryInto;
 use core::fmt;
 use core::ops::{Add, Mul, Neg, Sub};
-use ff::PrimeField;
-use pasta_curves::arithmetic::{FieldExt, Group, SqrtRatio};
+use ff::{FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -97,10 +96,8 @@ const ROOT_OF_UNITY_INV: Fr = Fr::from_raw([
     0x048127174daabc26,
 ]);
 
-/// GENERATOR^{2^s} where t * 2^s + 1 = r
-/// with t odd. In other words, this
-/// is a t root of unity.
-// 0x09226b6e22c6f0ca64ec26aad4c86e715b5f898e5e963f25870e56bbe533e9a2
+/// GENERATOR^{2^s} where t * 2^s + 1 = r with t odd. In other words, this is a t root of unity.
+/// 0x09226b6e22c6f0ca64ec26aad4c86e715b5f898e5e963f25870e56bbe533e9a2
 const DELTA: Fr = Fr::from_raw([
     0x870e56bbe533e9a2,
     0x5b5f898e5e963f25,
@@ -119,7 +116,7 @@ const ZETA: Fr = Fr::from_raw([
 use crate::{
     field_common, impl_add_binop_specify_output, impl_binops_additive,
     impl_binops_additive_specify_output, impl_binops_multiplicative,
-    impl_binops_multiplicative_mixed, impl_sub_binop_specify_output,
+    impl_binops_multiplicative_mixed, impl_sub_binop_specify_output, impl_sum_prod,
 };
 impl_binops_additive!(Fr, Fr);
 impl_binops_multiplicative!(Fr, Fr);
@@ -136,12 +133,16 @@ field_common!(
     R2,
     R3
 );
+impl_sum_prod!(Fr);
 #[cfg(not(feature = "asm"))]
 field_arithmetic!(Fr, MODULUS, INV, sparse);
 #[cfg(feature = "asm")]
 field_arithmetic_asm!(Fr, MODULUS, INV);
 
 impl ff::Field for Fr {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+
     fn random(mut rng: impl RngCore) -> Self {
         Self::from_u512([
             rng.next_u64(),
@@ -155,14 +156,6 @@ impl ff::Field for Fr {
         ])
     }
 
-    fn zero() -> Self {
-        Self::zero()
-    }
-
-    fn one() -> Self {
-        Self::one()
-    }
-
     fn double(&self) -> Self {
         self.double()
     }
@@ -170,11 +163,6 @@ impl ff::Field for Fr {
     #[inline(always)]
     fn square(&self) -> Self {
         self.square()
-    }
-
-    /// Computes the square root of this element, if it exists.
-    fn sqrt(&self) -> CtOption<Self> {
-        crate::arithmetic::sqrt_tonelli_shanks(self, &<Self as SqrtRatio>::T_MINUS1_OVER2)
     }
 
     /// Computes the multiplicative inverse of this element,
@@ -189,6 +177,21 @@ impl ff::Field for Fr {
 
         CtOption::new(tmp, !self.ct_eq(&Self::zero()))
     }
+
+    fn sqrt(&self) -> CtOption<Self> {
+        /// `(t - 1) // 2` where t * 2^s + 1 = p with t odd.
+        const T_MINUS1_OVER2: [u64; 4] = [
+            0xcdcb848a1f0fac9f,
+            0x0c0ac2e9419f4243,
+            0x098d014dc2822db4,
+            0x0000000183227397,
+        ];
+        ff::helpers::sqrt_tonelli_shanks(self, &T_MINUS1_OVER2)
+    }
+
+    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+        ff::helpers::sqrt_ratio_generic(num, div)
+    }
 }
 
 impl ff::PrimeField for Fr {
@@ -196,6 +199,12 @@ impl ff::PrimeField for Fr {
 
     const NUM_BITS: u32 = 254;
     const CAPACITY: u32 = 253;
+    const MODULUS: &'static str = MODULUS_STR;
+    const MULTIPLICATIVE_GENERATOR: Self = GENERATOR;
+    const ROOT_OF_UNITY: Self = ROOT_OF_UNITY;
+    const ROOT_OF_UNITY_INV: Self = ROOT_OF_UNITY_INV;
+    const TWO_INV: Self = TWO_INV;
+    const DELTA: Self = DELTA;
     const S: u32 = S;
 
     fn from_repr(repr: Self::Repr) -> CtOption<Self> {
@@ -241,29 +250,28 @@ impl ff::PrimeField for Fr {
     fn is_odd(&self) -> Choice {
         Choice::from(self.to_repr()[0] & 1)
     }
+}
 
-    fn multiplicative_generator() -> Self {
-        GENERATOR
-    }
-
-    fn root_of_unity() -> Self {
-        ROOT_OF_UNITY
+impl FromUniformBytes<64> for Fr {
+    /// Converts a 512-bit little endian integer into
+    /// an `Fr` by reducing by the modulus.
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+        Self::from_u512([
+            u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+            u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+            u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+            u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
+            u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
+            u64::from_le_bytes(bytes[48..56].try_into().unwrap()),
+            u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
+        ])
     }
 }
 
-impl SqrtRatio for Fr {
-    /// `(t - 1) // 2` where t * 2^s + 1 = p with t odd.
-    const T_MINUS1_OVER2: [u64; 4] = [
-        0xcdcb848a1f0fac9f,
-        0x0c0ac2e9419f4243,
-        0x098d014dc2822db4,
-        0x0000000183227397,
-    ];
-
-    fn get_lower_32(&self) -> u32 {
-        let tmp = Fr::montgomery_reduce(&[self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0]);
-        tmp.0[0] as u32
-    }
+// TODO: Check the correctness of this 3!!
+impl WithSmallOrderMulGroup<3> for Fr {
+    const ZETA: Self = ZETA;
 }
 
 #[cfg(test)]
@@ -296,19 +304,6 @@ mod test {
     }
 
     #[test]
-    fn test_root_of_unity() {
-        assert_eq!(
-            Fr::root_of_unity().pow_vartime(&[1 << Fr::S, 0, 0, 0]),
-            Fr::one()
-        );
-    }
-
-    #[test]
-    fn test_inv_root_of_unity() {
-        assert_eq!(Fr::ROOT_OF_UNITY_INV, Fr::root_of_unity().invert().unwrap());
-    }
-
-    #[test]
     fn test_field() {
         crate::tests::field::random_field_tests::<Fr>("bn256 scalar".to_string());
     }
@@ -318,7 +313,7 @@ mod test {
         assert_eq!(Fr::DELTA, GENERATOR.pow(&[1u64 << Fr::S, 0, 0, 0]));
         assert_eq!(
             Fr::DELTA,
-            Fr::multiplicative_generator().pow(&[1u64 << Fr::S, 0, 0, 0])
+            Fr::MULTIPLICATIVE_GENERATOR.pow(&[1u64 << Fr::S, 0, 0, 0])
         );
     }
 

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -730,23 +730,6 @@ macro_rules! new_curve_impl {
             type Affine = $name_affine;
         }
 
-        impl Group for $name {
-            type Scalar = $scalar;
-
-            fn group_zero() -> Self {
-                Self::identity()
-            }
-            fn group_add(&mut self, rhs: &Self) {
-                *self += *rhs;
-            }
-            fn group_sub(&mut self, rhs: &Self) {
-                *self -= *rhs;
-            }
-            fn group_scale(&mut self, by: &Self::Scalar) {
-                *self *= *by;
-            }
-        }
-
         // Affine implementations
 
         impl std::fmt::Debug for $name_affine {

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -530,7 +530,11 @@ macro_rules! new_curve_impl {
             const CURVE_ID: &'static str = $curve_id;
 
             fn endo(&self) -> Self {
-                self.endomorphism_base()
+                Self {
+                    x: self.x * Self::Base::ZETA,
+                    y: self.y,
+                    z: self.z,
+                }
             }
 
             fn jacobian_coordinates(&self) -> ($base, $base, $base) {

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -142,23 +142,6 @@ macro_rules! field_common {
             }
         }
 
-        impl Group for $field {
-            type Scalar = Self;
-
-            fn group_zero() -> Self {
-                Self::zero()
-            }
-            fn group_add(&mut self, rhs: &Self) {
-                *self += *rhs;
-            }
-            fn group_sub(&mut self, rhs: &Self) {
-                *self -= *rhs;
-            }
-            fn group_scale(&mut self, by: &Self::Scalar) {
-                *self *= *by;
-            }
-        }
-
         impl fmt::Debug for $field {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let tmp = self.to_repr();
@@ -288,41 +271,6 @@ macro_rules! field_common {
         impl<'a> From<&'a $field> for [u8; 32] {
             fn from(value: &'a $field) -> [u8; 32] {
                 value.to_repr()
-            }
-        }
-
-        impl FieldExt for $field {
-            const MODULUS: &'static str = $modulus_str;
-            const TWO_INV: Self = $two_inv;
-            const ROOT_OF_UNITY_INV: Self = $root_of_unity_inv;
-            const DELTA: Self = $delta;
-            const ZETA: Self = $zeta;
-
-            fn from_u128(v: u128) -> Self {
-                $field::from_raw([v as u64, (v >> 64) as u64, 0, 0])
-            }
-
-            /// Converts a 512-bit little endian integer into
-            /// a `$field` by reducing by the modulus.
-            fn from_bytes_wide(bytes: &[u8; 64]) -> $field {
-                $field::from_u512([
-                    u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
-                    u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
-                    u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
-                    u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
-                    u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
-                    u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
-                    u64::from_le_bytes(bytes[48..56].try_into().unwrap()),
-                    u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
-                ])
-            }
-
-            fn get_lower_128(&self) -> u128 {
-                let tmp = $field::montgomery_reduce(&[
-                    self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0,
-                ]);
-
-                u128::from(tmp.0[0]) | (u128::from(tmp.0[1]) << 64)
             }
         }
 

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -162,3 +162,22 @@ macro_rules! impl_binops_multiplicative {
         }
     };
 }
+
+#[macro_export]
+macro_rules! impl_sum_prod {
+    ($f:ident) => {
+        impl<T: ::core::borrow::Borrow<$f>> ::core::iter::Sum<T> for $f {
+            fn sum<I: Iterator<Item = T>>(iter: I) -> Self {
+                use ::ff::Field;
+                iter.fold(Self::ZERO, |acc, item| acc + item.borrow())
+            }
+        }
+
+        impl<T: ::core::borrow::Borrow<$f>> ::core::iter::Product<T> for $f {
+            fn product<I: Iterator<Item = T>>(iter: I) -> Self {
+                use ::ff::Field;
+                iter.fold(Self::ONE, |acc, item| acc * item.borrow())
+            }
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,8 @@ pub mod serde;
 
 #[macro_use]
 mod derive;
-
 pub use arithmetic::CurveAffineExt;
-pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt, FieldExt, Group};
+pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
 pub extern crate group;
 

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -1,5 +1,6 @@
-use crate::{CurveAffine, FieldExt, Group as _Group};
+use crate::CurveAffine;
 use core::ops::Mul;
+use ff::Field;
 use group::{
     prime::PrimeCurve, Group, GroupOps, GroupOpsOwned, ScalarMul, ScalarMulOwned,
     UncompressedEncoding,
@@ -7,7 +8,7 @@ use group::{
 
 pub trait Engine: Sized + 'static + Clone {
     /// This is the scalar field of the engine's groups.
-    type Scalar: FieldExt;
+    type Scalar: Field;
 
     /// The projective representation of an element in G1.
     type G1: PrimeCurve<Scalar = Self::Scalar, Affine = Self::G1Affine>
@@ -16,7 +17,7 @@ pub trait Engine: Sized + 'static + Clone {
         + GroupOpsOwned<Self::G1Affine>
         + ScalarMul<Self::Scalar>
         + ScalarMulOwned<Self::Scalar>
-        + _Group<Scalar = Self::Scalar>;
+        + Group<Scalar = Self::Scalar>;
 
     /// The affine representation of an element in G1.
     type G1Affine: PairingCurveAffine<

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -5,17 +5,12 @@ use core::cmp;
 use core::fmt::Debug;
 use core::iter::Sum;
 use core::ops::{Add, Mul, Neg, Sub};
+use ff::WithSmallOrderMulGroup;
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Curve, Group as _, GroupEncoding};
 
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
-
-impl Secp256k1 {
-    fn endomorphism_base(&self) -> Self {
-        unimplemented!();
-    }
-}
 
 impl group::cofactor::CofactorGroup for Secp256k1 {
     type Subgroup = Secp256k1;
@@ -82,6 +77,12 @@ fn test_curve() {
 #[test]
 fn test_serialization() {
     crate::tests::curve::random_serialization_test::<Secp256k1>();
+}
+
+#[test]
+fn test_endo_consistency() {
+    let g = Secp256k1::generator();
+    assert_eq!(g * Fq::ZETA, g.endo());
 }
 
 #[test]

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -1,13 +1,12 @@
 use crate::secp256k1::Fp;
 use crate::secp256k1::Fq;
-use crate::{Coordinates, CurveAffine, CurveAffineExt, CurveExt, Group};
+use crate::{Coordinates, CurveAffine, CurveAffineExt, CurveExt};
 use core::cmp;
 use core::fmt::Debug;
 use core::iter::Sum;
 use core::ops::{Add, Mul, Neg, Sub};
 use ff::{Field, PrimeField};
-use group::Curve;
-use group::{prime::PrimeCurveAffine, Group as _, GroupEncoding};
+use group::{prime::PrimeCurveAffine, Curve, Group as _, GroupEncoding};
 
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -88,7 +87,8 @@ fn test_serialization() {
 #[test]
 fn ecdsa_example() {
     use crate::group::Curve;
-    use crate::{CurveAffine, FieldExt};
+    use crate::CurveAffine;
+    use ff::FromUniformBytes;
     use rand_core::OsRng;
 
     fn mod_n(x: Fp) -> Fq {
@@ -96,7 +96,7 @@ fn ecdsa_example() {
         x_repr.copy_from_slice(x.to_repr().as_ref());
         let mut x_bytes = [0u8; 64];
         x_bytes[..32].copy_from_slice(&x_repr[..]);
-        Fq::from_bytes_wide(&x_bytes)
+        Fq::from_uniform_bytes(&x_bytes)
     }
 
     let g = Secp256k1::generator();

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -83,7 +83,7 @@ const DELTA: Fp = Fp([0x900002259u64, 0, 0, 0]);
 
 /// Implementations of this trait MUST ensure that this is the generator used to derive Self::ROOT_OF_UNITY.
 /// Derived from:
-/// ```
+/// ```ignore
 /// Zp(Zp(mul_generator)^t) where t = (modulus - 1 )/ 2
 /// 115792089237316195423570985008687907853269984665640564039457584007908834671662
 /// ```

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -84,7 +84,7 @@ const DELTA: Fp = Fp([0x900002259u64, 0, 0, 0]);
 /// Implementations of this trait MUST ensure that this is the generator used to derive Self::ROOT_OF_UNITY.
 /// Derived from:
 /// ```
-/// Zp((Zp(mul_generator)^((modulus -1)/2)))
+/// Zp(Zp(mul_generator)^t) where t = (modulus - 1 )/ 2
 /// 115792089237316195423570985008687907853269984665640564039457584007908834671662
 /// ```
 const ROOT_OF_UNITY: Fp = Fp([
@@ -284,7 +284,6 @@ impl FromUniformBytes<64> for Fp {
     }
 }
 
-// TODO: Check correctness of the 3!!!
 impl WithSmallOrderMulGroup<3> for Fp {
     const ZETA: Self = ZETA;
 }

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -289,7 +289,6 @@ impl WithSmallOrderMulGroup<3> for Fp {
 mod test {
     use super::*;
     use ff::Field;
-    use num_traits::Pow;
     use rand_core::OsRng;
 
     #[test]

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -69,9 +69,13 @@ const TWO_INV: Fp = Fp::from_raw([
     0x7fffffffffffffff,
 ]);
 
-// TODO: Why are ZETA and DELTA == `0`?
+// TODO: Why is ZETA == `0`?
 const ZETA: Fp = Fp::zero();
-const DELTA: Fp = Fp::zero();
+
+/// Generator of the t-order multiplicative subgroup.
+/// Computed by exponentiating Self::MULTIPLICATIVE_GENERATOR by 2^s, where s is Self::S.
+/// `0x0000000000000000000000000000000000000000000000000000000000000009`.
+const DELTA: Fp = Fp([0x900002259u64, 0, 0, 0]);
 
 /// Implementations of this trait MUST ensure that this is the generator used to derive Self::ROOT_OF_UNITY.
 /// Derived from:
@@ -285,6 +289,7 @@ impl WithSmallOrderMulGroup<3> for Fp {
 mod test {
     use super::*;
     use ff::Field;
+    use num_traits::Pow;
     use rand_core::OsRng;
 
     #[test]
@@ -304,6 +309,24 @@ mod test {
 
             assert!(a == b || a == negb);
         }
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(
+            Fp::MODULUS,
+            "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+        );
+
+        assert_eq!(Fp::from(2) * Fp::TWO_INV, Fp::ONE);
+    }
+
+    #[test]
+    fn test_delta() {
+        assert_eq!(
+            Fp::DELTA,
+            MULTIPLICATIVE_GENERATOR.pow(&[1u64 << Fp::S, 0, 0, 0])
+        );
     }
 
     #[test]

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -69,8 +69,12 @@ const TWO_INV: Fp = Fp::from_raw([
     0x7fffffffffffffff,
 ]);
 
-// TODO: Why is ZETA == `0`?
-const ZETA: Fp = Fp::zero();
+const ZETA: Fp = Fp::from_raw([
+    0xc1396c28719501ee,
+    0x9cf0497512f58995,
+    0x6e64479eac3434e9,
+    0x7ae96a2b657c0710,
+]);
 
 /// Generator of the t-order multiplicative subgroup.
 /// Computed by exponentiating Self::MULTIPLICATIVE_GENERATOR by 2^s, where s is Self::S.

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -291,7 +291,6 @@ impl FromUniformBytes<64> for Fq {
     }
 }
 
-// TODO: Check the correctness of this 3!!
 impl WithSmallOrderMulGroup<3> for Fq {
     const ZETA: Self = ZETA;
 }

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -72,9 +72,7 @@ const R3: Fq = Fq([
 /// It's derived with SageMath with: `GF(MODULUS).primitive_element()`.
 const GENERATOR: Fq = Fq::from_raw([0x07, 0x00, 0x00, 0x00]);
 
-/// GENERATOR^t where t * 2^s + 1 = r
-/// with t odd. In other words, this
-/// is a 2^s root of unity.
+/// GENERATOR^t where t * 2^s + 1 = r with t odd. In other words, this is a 2^s root of unity.
 /// `0xc1dc060e7a91986df9879a3fbc483a898bdeab680756045992f4b5402b052f2`
 const ROOT_OF_UNITY: Fq = Fq::from_raw([
     0x992f4b5402b052f2,
@@ -99,8 +97,18 @@ const TWO_INV: Fq = Fq::from_raw([
     0x7fffffffffffffff,
 ]);
 
+/// TODO: Is it correct for this to be 0???
 const ZETA: Fq = Fq::zero();
-const DELTA: Fq = Fq::zero();
+
+/// Generator of the t-order multiplicative subgroup.
+/// Computed by exponentiating Self::MULTIPLICATIVE_GENERATOR by 2^s, where s is Self::S.
+/// `0x0000000000000000000cbc21fe4561c8d63b78e780e1341e199417c8c0bb7601`
+const DELTA: Fq = Fq([
+    0xd91b33d24319d9e8,
+    0xb81c6596ff5d6740,
+    0xa463969ca14c51c1,
+    0x1900960de4b7929c,
+]);
 
 use crate::{
     field_arithmetic, field_common, field_specific, impl_add_binop_specify_output,
@@ -321,7 +329,6 @@ mod test {
 
     #[test]
     fn test_delta() {
-        assert_eq!(Fq::DELTA, GENERATOR.pow(&[1u64 << Fq::S, 0, 0, 0]));
         assert_eq!(
             Fq::DELTA,
             Fq::MULTIPLICATIVE_GENERATOR.pow(&[1u64 << Fq::S, 0, 0, 0])
@@ -350,6 +357,4 @@ mod test {
     fn test_serialization() {
         crate::tests::field::random_serialization_test::<Fq>("secp256k1 scalar".to_string());
     }
-
-    // TODO: Add a test for the new ROOT_OF_UNITY
 }

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -97,8 +97,12 @@ const TWO_INV: Fq = Fq::from_raw([
     0x7fffffffffffffff,
 ]);
 
-/// TODO: Is it correct for this to be 0???
-const ZETA: Fq = Fq::zero();
+const ZETA: Fq = Fq::from_raw([
+    0xdf02967c1b23bd72,
+    0x122e22ea20816678,
+    0xa5261c028812645a,
+    0x5363ad4cc05c30e0,
+]);
 
 /// Generator of the t-order multiplicative subgroup.
 /// Computed by exponentiating Self::MULTIPLICATIVE_GENERATOR by 2^s, where s is Self::S.

--- a/src/tests/curve.rs
+++ b/src/tests/curve.rs
@@ -264,10 +264,10 @@ fn multiplication<G: CurveExt>() {
         assert!(bool::from(t0.is_identity()));
 
         let a = G::random(OsRng);
-        let t0 = a * G::ScalarExt::one();
+        let t0 = a * G::ScalarExt::ONE;
         assert_eq!(a, t0);
 
-        let t0 = a * G::ScalarExt::zero();
+        let t0 = a * G::ScalarExt::ZERO;
         assert!(bool::from(t0.is_identity()));
 
         let t0 = a * s1 + a * s2;

--- a/src/tests/field.rs
+++ b/src/tests/field.rs
@@ -46,8 +46,8 @@ pub fn random_field_tests<F: Field>(type_name: String) {
 }
 
 fn random_multiplication_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let message = format!("multiplication {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("multiplication {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
         let b = F::random(&mut rng);
@@ -72,8 +72,8 @@ fn random_multiplication_tests<F: Field, R: RngCore>(mut rng: R, type_name: Stri
 }
 
 fn random_addition_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let message = format!("addition {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("addition {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
         let b = F::random(&mut rng);
@@ -98,8 +98,8 @@ fn random_addition_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_subtraction_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let message = format!("subtraction {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("subtraction {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
         let b = F::random(&mut rng);
@@ -119,8 +119,8 @@ fn random_subtraction_tests<F: Field, R: RngCore>(mut rng: R, type_name: String)
 }
 
 fn random_negation_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let message = format!("negation {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("negation {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
         let mut b = a;
@@ -133,8 +133,8 @@ fn random_negation_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_doubling_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let message = format!("doubling {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("doubling {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let mut a = F::random(&mut rng);
         let mut b = a;
@@ -147,8 +147,8 @@ fn random_doubling_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_squaring_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let message = format!("squaring {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("squaring {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let mut a = F::random(&mut rng);
         let mut b = a;
@@ -163,8 +163,8 @@ fn random_squaring_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 fn random_inversion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
     assert!(bool::from(F::ZERO.invert().is_none()));
 
-    let message = format!("inversion {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("inversion {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let mut a = F::random(&mut rng);
         let b = a.invert().unwrap(); // probablistically nonzero
@@ -176,8 +176,8 @@ fn random_inversion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_expansion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let message = format!("expansion {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("expansion {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         // Compare (a + b)(c + d) and (a*c + b*c + a*d + b*d)
 
@@ -215,8 +215,8 @@ pub fn random_serialization_test<F: Field + SerdeObject>(type_name: String) {
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
     ]);
-    let message = format!("serialization {}", type_name);
-    let start = start_timer!(|| message);
+    let _message = format!("serialization {}", type_name);
+    let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
         let bytes = a.to_raw_bytes();

--- a/src/tests/field.rs
+++ b/src/tests/field.rs
@@ -20,19 +20,19 @@ pub fn random_field_tests<F: Field>(type_name: String) {
     random_inversion_tests::<F, _>(&mut rng, type_name.clone());
     random_expansion_tests::<F, _>(&mut rng, type_name);
 
-    assert_eq!(F::zero().is_zero().unwrap_u8(), 1);
+    assert_eq!(F::ZERO.is_zero().unwrap_u8(), 1);
     {
-        let mut z = F::zero();
+        let mut z = F::ZERO;
         z = z.neg();
         assert_eq!(z.is_zero().unwrap_u8(), 1);
     }
 
-    assert!(bool::from(F::zero().invert().is_none()));
+    assert!(bool::from(F::ZERO.invert().is_none()));
 
     // Multiplication by zero
     {
         let mut a = F::random(&mut rng);
-        a.mul_assign(&F::zero());
+        a.mul_assign(&F::ZERO);
         assert_eq!(a.is_zero().unwrap_u8(), 1);
     }
 
@@ -40,7 +40,7 @@ pub fn random_field_tests<F: Field>(type_name: String) {
     {
         let mut a = F::random(&mut rng);
         let copy = a;
-        a.add_assign(&F::zero());
+        a.add_assign(&F::ZERO);
         assert_eq!(a, copy);
     }
 }
@@ -161,7 +161,7 @@ fn random_squaring_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_inversion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    assert!(bool::from(F::zero().invert().is_none()));
+    assert!(bool::from(F::ZERO.invert().is_none()));
 
     let message = format!("inversion {}", type_name);
     let start = start_timer!(|| message);
@@ -170,7 +170,7 @@ fn random_inversion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
         let b = a.invert().unwrap(); // probablistically nonzero
         a.mul_assign(&b);
 
-        assert_eq!(a, F::one());
+        assert_eq!(a, F::ONE);
     }
     end_timer!(start);
 }


### PR DESCRIPTION
Since `ff` and `group` 0.13.0 versions and 0.5.0 release for `pasta_curves`, `FieldExt` and `Group` traits have been merged into `Field` and `PrimeField`.
Also, some new traits have appeared such as `WithSmallOrderMultiplicative` and `FromUniformBytes`.

This PR reworks the implementation of all the aforementioned traits to be able to update the codebase to the latest `ff`, `group` and `pasta_curves` dependency versions.

Also, note that aside from the trait-related work, some constants have been computed and included in the lib. And others have been left to `0` as they'll never be used.
In any case, I've left with `TODO` marked all the things I'd like advice for.

Resolves: #18 