### PR TITLE
optimize "mul by 3b"

### DIFF
--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -420,12 +420,10 @@ macro_rules! new_curve_impl {
             }
 
             fn mul_by_3b(input: &$base) -> $base {
-                // b = 3 for bn254 curve
-                if $name::curve_constant_3b() == $base::from(9) {
-                    let tmp = input.double().double().double();
-                    tmp+input
+                if $name::CURVE_ID == "bn256"{
+                    input.double().double().double() + input
                 } else {
-                    panic!("do not currently support")
+                    input * $name::curve_constant_3b()
                 }
             }
         }

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -417,7 +417,16 @@ macro_rules! new_curve_impl {
                         static ref CONST_3B: $base = $constant_b + $constant_b + $constant_b;
                 }
                 *CONST_3B
+            }
 
+            fn mul_by_3b(input: &$base) -> $base {
+                // b = 3 for bn254 curve
+                if $name::curve_constant_3b() == $base::from(9) {
+                    let tmp = input.double().double().double();
+                    tmp+input
+                } else {
+                    panic!("do not currently support")
+                }
             }
         }
 
@@ -644,7 +653,7 @@ macro_rules! new_curve_impl {
                 let z3 = z3 + z3;
                 let t1 = self.y * self.z;
                 let t2 = self.z.square();
-                let t2 = t2 * $name::curve_constant_3b();
+                let t2 = $name::mul_by_3b(&t2);
                 let x3 = t2 * z3;
                 let y3 = t0 + t2;
                 let z3 = t1 * z3;
@@ -971,10 +980,10 @@ macro_rules! new_curve_impl {
                 let y3 = x3 - y3;
                 let x3 = t0 + t0;
                 let t0 = x3 + t0;
-                let t2 = t2 * $name::curve_constant_3b();
+                let t2 = $name::mul_by_3b(&t2);
                 let z3 = t1 + t2;
                 let t1 = t1 - t2;
-                let y3 = y3 * $name::curve_constant_3b();
+                let y3 = $name::mul_by_3b(&y3);
                 let x3 = t4 * y3;
                 let t2 = t3 * t1;
                 let x3 = t2 - x3;
@@ -1013,10 +1022,10 @@ macro_rules! new_curve_impl {
                 let y3 = y3 + self.x;
                 let x3 = t0 + t0;
                 let t0 = x3 + t0;
-                let t2 = self.z * $name::curve_constant_3b();
+                let t2 = $name::mul_by_3b(&self.z);
                 let z3 = t1 + t2;
                 let t1 = t1 - t2;
-                let y3 = y3 * $name::curve_constant_3b();
+                let y3 = $name::mul_by_3b(&y3);
                 let x3 = t4 * y3;
                 let t2 = t3 * t1;
                 let x3 = t2 - x3;


### PR DESCRIPTION
f33059b1be8fee408e156c155dd009bfbff32969 (this PR)
Group operations/double/                                                                            
                        time:   [226.02 µs 227.16 µs 228.61 µs]
Group operations/add/   time:   [322.37 µs 322.60 µs 322.85 µs]                                  

67cc0a2a6bf4fd7f986669504202ca29261bf644 (before this PR)
Group operations/double/                                                                            
                        time:   [235.54 µs 235.64 µs 235.75 µs]
Group operations/add/   time:   [323.36 µs 323.60 µs 323.86 µs]  


093c4dc12bee6ca54a0254534ba2d6497f3b3d67 (using old formula)
Group operations/double/                                                                            
                        time:   [198.25 µs 198.31 µs 198.38 µs]
Group operations/add/   time:   [387.00 µs 387.26 µs 387.54 µs]                                  

