### PR TITLE
Add basic group operation benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ readme = "README.md"
 description = "Elliptic curve implementations and wrappers for halo2 library"
 rust-version = "1.63.0"
 
+[[bench]]
+name = "group"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
 rand_xorshift = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,6 @@ readme = "README.md"
 description = "Elliptic curve implementations and wrappers for halo2 library"
 rust-version = "1.63.0"
 
-[[bench]]
-name = "group"
-harness = false
-
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
 rand_xorshift = "0.3"
@@ -63,3 +59,7 @@ harness = false
 name = "bn256_field"
 harness = false
 required-features = ["reexport"]
+
+[[bench]]
+name = "group"
+harness = false

--- a/benches/group.rs
+++ b/benches/group.rs
@@ -1,0 +1,51 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ff::Field;
+use group::prime::PrimeCurveAffine;
+use halo2curves::secp256k1::Secp256k1;
+use pasta_curves::arithmetic::{CurveAffine, CurveExt};
+use rand_core::OsRng;
+
+fn criterion_benchmark<G: CurveExt>(c: &mut Criterion) {
+    // G1Projective
+    {
+        let name = "GProjective";
+        let a = G::generator();
+        let a_affine = G::AffineExt::generator();
+        let s = G::ScalarExt::random(OsRng);
+
+        const N: usize = 1000;
+        let v = vec![G::generator(); N];
+        let mut q = vec![G::AffineExt::identity(); N];
+
+        c.bench_function(&format!("{} check on curve", name), move |b| {
+            b.iter(|| black_box(a).is_on_curve())
+        });
+        c.bench_function(&format!("{} check equality", name), move |b| {
+            b.iter(|| black_box(a) == black_box(a))
+        });
+        c.bench_function(&format!("{} to affine", name), move |b| {
+            b.iter(|| G::AffineExt::from(black_box(a)))
+        });
+        c.bench_function(&format!("{} doubling", name), move |b| {
+            b.iter(|| black_box(a).double())
+        });
+        c.bench_function(&format!("{} addition", name), move |b| {
+            b.iter(|| black_box(a).add(&a))
+        });
+        c.bench_function(&format!("{} mixed addition", name), move |b| {
+            b.iter(|| black_box(a).add(&a_affine))
+        });
+        c.bench_function(&format!("{} scalar multiplication", name), move |b| {
+            b.iter(|| black_box(a) * black_box(s))
+        });
+        c.bench_function(&format!("{} batch to affine n={}", name, N), move |b| {
+            b.iter(|| {
+                G::batch_normalize(black_box(&v), black_box(&mut q));
+                black_box(&q)[0]
+            })
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark<Secp256k1>);
+criterion_main!(benches);

--- a/benches/group.rs
+++ b/benches/group.rs
@@ -2,15 +2,16 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ff::Field;
 use group::prime::PrimeCurveAffine;
 use halo2curves::secp256k1::Secp256k1;
-use pasta_curves::arithmetic::{CurveAffine, CurveExt};
+use pasta_curves::arithmetic::CurveExt;
 use rand_core::OsRng;
 
 fn criterion_benchmark<G: CurveExt>(c: &mut Criterion) {
     // G1Projective
     {
         let name = "GProjective";
-        let a = G::generator();
-        let a_affine = G::AffineExt::generator();
+        let p1 = G::random(OsRng);
+        let p2 = G::random(OsRng);
+        let p1_affine = G::AffineExt::from(p1);
         let s = G::ScalarExt::random(OsRng);
 
         const N: usize = 1000;
@@ -18,25 +19,25 @@ fn criterion_benchmark<G: CurveExt>(c: &mut Criterion) {
         let mut q = vec![G::AffineExt::identity(); N];
 
         c.bench_function(&format!("{} check on curve", name), move |b| {
-            b.iter(|| black_box(a).is_on_curve())
+            b.iter(|| black_box(p1).is_on_curve())
         });
         c.bench_function(&format!("{} check equality", name), move |b| {
-            b.iter(|| black_box(a) == black_box(a))
+            b.iter(|| black_box(p1) == black_box(p1))
         });
         c.bench_function(&format!("{} to affine", name), move |b| {
-            b.iter(|| G::AffineExt::from(black_box(a)))
+            b.iter(|| G::AffineExt::from(black_box(p1)))
         });
         c.bench_function(&format!("{} doubling", name), move |b| {
-            b.iter(|| black_box(a).double())
+            b.iter(|| black_box(p1).double())
         });
         c.bench_function(&format!("{} addition", name), move |b| {
-            b.iter(|| black_box(a).add(&a))
+            b.iter(|| black_box(p1).add(&p2))
         });
         c.bench_function(&format!("{} mixed addition", name), move |b| {
-            b.iter(|| black_box(a).add(&a_affine))
+            b.iter(|| black_box(p2).add(&p1_affine))
         });
         c.bench_function(&format!("{} scalar multiplication", name), move |b| {
-            b.iter(|| black_box(a) * black_box(s))
+            b.iter(|| black_box(p1) * black_box(s))
         });
         c.bench_function(&format!("{} batch to affine n={}", name, N), move |b| {
             b.iter(|| {

--- a/benches/less_than.rs
+++ b/benches/less_than.rs
@@ -1,5 +1,7 @@
 #![allow(unused)]
 
+mod group;
+
 use criterion::BenchmarkId;
 
 /// Compute a - (b + borrow), returning the result and the new borrow.

--- a/benches/less_than.rs
+++ b/benches/less_than.rs
@@ -1,7 +1,5 @@
 #![allow(unused)]
 
-mod group;
-
 use criterion::BenchmarkId;
 
 /// Compute a - (b + borrow), returning the result and the new borrow.


### PR DESCRIPTION
The purpose of this PR is to add benchmarks for all basic group operations.
In particular we want to evaluate the impact on performance that the changes introduced by #19 have had.