### PR TITLE
[feat] using the old ETA for backwards compatibility

### DIFF
--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -194,10 +194,10 @@ mod tests {
     #[test]
     fn test_endo_consistency() {
         let g = G1::generator();
-        assert_eq!(g * Fr::ZETA, g.endo());
+        assert_eq!(g * (-Fr::ZETA), g.endo());
 
         let g = G2::generator();
-        assert_eq!(g * Fr::ZETA, g.endo());
+        assert_eq!(g * (-Fr::ZETA), g.endo());
     }
 
     #[test]

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -111,10 +111,10 @@ const DELTA: Fr = Fr::from_raw([
 
 /// `ZETA^3 = 1 mod r` where `ZETA^2 != 1 mod r`
 const ZETA: Fr = Fr::from_raw([
-    0x8b17ea66b99c90dd,
-    0x5bfc41088d8daaa7,
-    0xb3c4d79d41a91758,
-    0x00,
+    0xb8ca0b2d36636f23,
+    0xcc37a73fec2bc5e9,
+    0x048b6e193fd84104,
+    0x30644e72e131a029,
 ]);
 
 use crate::{


### PR DESCRIPTION
as per discussions over telegram, reverting ETA for better backwards compatibility.
changes that are reverted:

https://github.com/privacy-scaling-explorations/halo2curves/commit/67cc0a2a6bf4fd7f986669504202ca29261bf644#diff-0d4f21d7b4c85f5a4e46fbb59f8ec28acfdb731b1e21855d7d4a70a361d3db28L262

https://github.com/privacy-scaling-explorations/halo2curves/commit/f18aad3bdf7cf6b31ca76cd4e986d6cfd648c3e2#diff-a60fb2523c0d91836861d1e8f82b4741cfa28c7368d70b027ba981bfe084d68fL109