### PR TITLE
Add `secp256r1` curve

### DIFF
--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -35,6 +35,7 @@ new_curve_impl!(
     Fq,
     Fr,
     (G1_GENERATOR_X,G1_GENERATOR_Y),
+    G1_A,
     G1_B,
     "bn256_g1",
 );
@@ -47,6 +48,7 @@ new_curve_impl!(
     Fq2,
     Fr,
     (G2_GENERATOR_X, G2_GENERATOR_Y),
+    G2_A,
     G2_B,
     "bn256_g2",
 );
@@ -69,7 +71,13 @@ impl CurveAffineExt for G2Affine {
 
 const G1_GENERATOR_X: Fq = Fq::one();
 const G1_GENERATOR_Y: Fq = Fq::from_raw([2, 0, 0, 0]);
+const G1_A: Fq = Fq::from_raw([0, 0, 0, 0]);
 const G1_B: Fq = Fq::from_raw([3, 0, 0, 0]);
+
+const G2_A: Fq2 = Fq2 {
+    c0: Fq::from_raw([0, 0, 0, 0]),
+    c1: Fq::from_raw([0, 0, 0, 0]),
+};
 
 const G2_B: Fq2 = Fq2 {
     c0: Fq::from_raw([

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -101,7 +101,6 @@ const TWO_INV: Fq = Fq::from_raw([
     0x183227397098d014,
 ]);
 
-// TODO: Can we simply put 0 here::
 const ROOT_OF_UNITY: Fq = Fq::zero();
 
 // Unused constant for base field

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -101,13 +101,24 @@ const TWO_INV: Fq = Fq::from_raw([
     0x183227397098d014,
 ]);
 
-const ROOT_OF_UNITY: Fq = Fq::zero();
+/// `0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46`
+const ROOT_OF_UNITY: Fq = Fq::from_raw([
+    0x3c208c16d87cfd46,
+    0x97816a916871ca8d,
+    0xb85045b68181585d,
+    0x30644e72e131a029,
+]);
 
-// Unused constant for base field
-const ROOT_OF_UNITY_INV: Fq = Fq::zero();
+/// `0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46`
+const ROOT_OF_UNITY_INV: Fq = Fq::from_raw([
+    0x3c208c16d87cfd46,
+    0x97816a916871ca8d,
+    0xb85045b68181585d,
+    0x30644e72e131a029,
+]);
 
-// Unused constant for base field
-const DELTA: Fq = Fq::zero();
+// `0x9`
+const DELTA: Fq = Fq::from_raw([0x9, 0, 0, 0]);
 
 /// `ZETA^3 = 1 mod r` where `ZETA^2 != 1 mod r`
 const ZETA: Fq = Fq::from_raw([

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -200,6 +200,7 @@ macro_rules! new_curve_impl {
     $base:ident,
     $scalar:ident,
     $generator:expr,
+    $constant_a:expr,
     $constant_b:expr,
     $curve_id:literal,
     ) => {
@@ -255,7 +256,7 @@ macro_rules! new_curve_impl {
                         $base::from_bytes(&xbytes).and_then(|x| {
                             CtOption::new(Self::identity(), x.is_zero() & (is_inf)).or_else(|| {
                                 let x3 = x.square() * x;
-                                (x3 + $name::curve_constant_b()).sqrt().and_then(|y| {
+                                (x3 + $name::curve_constant_a() * x + $name::curve_constant_b()).sqrt().and_then(|y| {
                                     let sign = Choice::from(y.to_bytes()[0] & 1);
 
                                     let y = $base::conditional_select(&y, &-y, ysign ^ sign);
@@ -461,6 +462,10 @@ macro_rules! new_curve_impl {
                 }
             }
 
+            const fn curve_constant_a() -> $base {
+                $name_affine::curve_constant_a()
+            }
+
             const fn curve_constant_b() -> $base {
                 $name_affine::curve_constant_b()
             }
@@ -490,6 +495,10 @@ macro_rules! new_curve_impl {
                 }
             }
 
+            const fn curve_constant_a() -> $base {
+                $constant_a
+            }
+
             const fn curve_constant_b() -> $base {
                 $constant_b
             }
@@ -501,7 +510,7 @@ macro_rules! new_curve_impl {
                     let ysign = (rng.next_u32() % 2) as u8;
 
                     let x3 = x.square() * x;
-                    let y = (x3 + $name::curve_constant_b()).sqrt();
+                    let y = (x3 + $name::curve_constant_a() * x + $name::curve_constant_b()).sqrt();
                     if let Some(y) = Option::<$base>::from(y) {
                         let sign = y.to_bytes()[0] & 1;
                         let y = if ysign ^ sign == 0 { y } else { -y };
@@ -611,10 +620,10 @@ macro_rules! new_curve_impl {
             }
 
             fn is_on_curve(&self) -> Choice {
-                // Check (Y/Z)^2 = (X/Z)^3 + b
-                // <=>    Z Y^2 -  X^3 = Z^3 b
+                // Check (Y/Z)^2 = (X/Z)^3 + a(X/Z) + b
+                // <=>    Z Y^2 -  X^3 - a(X Z^2) = Z^3 b
 
-                (self.z * self.y.square()  - self.x.square() * self.x)
+                (self.z * self.y.square()  - self.x.square() * self.x - $name::curve_constant_a() * self.x * self.z.square())
                     .ct_eq(&(self.z.square() * self.z * $name::curve_constant_b()))
                     | self.z.is_zero()
             }
@@ -624,7 +633,7 @@ macro_rules! new_curve_impl {
             }
 
             fn a() -> Self::Base {
-                Self::Base::zero()
+                $name::curve_constant_a()
             }
 
             fn new_jacobian(x: Self::Base, y: Self::Base, z: Self::Base) -> CtOption<Self> {
@@ -698,25 +707,38 @@ macro_rules! new_curve_impl {
             }
 
             fn double(&self) -> Self {
-                // Algorithm 9, https://eprint.iacr.org/2015/1060.pdf
-                let t0 = self.y.square();
-                let z3 = t0 + t0;
-                let z3 = z3 + z3;
-                let z3 = z3 + z3;
-                let t1 = self.y * self.z;
+                // Algorithm 3, https://eprint.iacr.org/2015/1060.pdf
+                let t0 = self.x.square();
+                let t1 = self.y.square();
                 let t2 = self.z.square();
-                let t2 = $name::mul_by_3b(&t2);
-                let x3 = t2 * z3;
-                let y3 = t0 + t2;
-                let z3 = t1 * z3;
-                let t1 = t2 + t2;
-                let t2 = t1 + t2;
-                let t0 = t0 - t2;
-                let y3 = t0 * y3;
+                let t3 = self.x * self.y;
+                let t3 = t3 + t3;
+                let z3 = self.x * self.z;
+                let z3 = z3 + z3;
+                let x3 = $name::curve_constant_a() * z3;
+                let y3 = $name::mul_by_3b(&t2);
                 let y3 = x3 + y3;
-                let t1 = self.x * self.y;
-                let x3 = t0 * t1;
-                let x3 = x3 + x3;
+                let x3 = t1 - y3;
+                let y3 = t1 + y3;
+                let y3 = x3 * y3;
+                let x3 = t3 * x3;
+                let z3 = $name::mul_by_3b(&z3);
+                let t2 = $name::curve_constant_a() * t2;
+                let t3 = t0 - t2;
+                let t3 = $name::curve_constant_a() * t3;
+                let t3 = t3 + z3;
+                let z3 = t0 + t0;
+                let t0 = z3 + t0;
+                let t0 = t0 + t2;
+                let t0 = t0 * t3;
+                let y3 = y3 + t0;
+                let t2 = self.y * self.z;
+                let t2 = t2 + t2;
+                let t0 = t2 * t3;
+                let x3 = x3 - t0;
+                let z3 = t2 * t1;
+                let z3 = z3 + z3;
+                let z3 = z3 + z3;
 
                 let tmp = $name {
                     x: x3,
@@ -942,8 +964,8 @@ macro_rules! new_curve_impl {
             type CurveExt = $name;
 
             fn is_on_curve(&self) -> Choice {
-                // y^2 - x^3 ?= b
-                (self.y.square() - self.x.square() * self.x).ct_eq(&$name::curve_constant_b())
+                // y^2 - x^3 - ax ?= b
+                (self.y.square() - self.x.square() * self.x - $name::curve_constant_a() * self.x).ct_eq(&$name::curve_constant_b())
                     | self.is_identity()
             }
 
@@ -959,7 +981,7 @@ macro_rules! new_curve_impl {
             }
 
             fn a() -> Self::Base {
-                Self::Base::zero()
+                $name::curve_constant_a()
             }
 
             fn b() -> Self::Base {
@@ -1011,7 +1033,7 @@ macro_rules! new_curve_impl {
             type Output = $name;
 
             fn add(self, rhs: &'a $name) -> $name {
-                // Algorithm 7, https://eprint.iacr.org/2015/1060.pdf
+                // Algorithm 1, https://eprint.iacr.org/2015/1060.pdf
                 let t0 = self.x * rhs.x;
                 let t1 = self.y * rhs.y;
                 let t2 = self.z * rhs.z;
@@ -1020,30 +1042,37 @@ macro_rules! new_curve_impl {
                 let t3 = t3 * t4;
                 let t4 = t0 + t1;
                 let t3 = t3 - t4;
-                let t4 = self.y + self.z;
+                let t4 = self.x + self.z;
+                let t5 = rhs.x + rhs.z;
+                let t4 = t4 * t5;
+                let t5 = t0 + t2;
+                let t4 = t4 - t5;
+                let t5 = self.y + self.z;
                 let x3 = rhs.y + rhs.z;
-                let t4 = t4 * x3;
+                let t5 = t5 * x3;
                 let x3 = t1 + t2;
-                let t4 = t4 - x3;
-                let x3 = self.x + self.z;
-                let y3 = rhs.x + rhs.z;
-                let x3 = x3 * y3;
-                let y3 = t0 + t2;
-                let y3 = x3 - y3;
-                let x3 = t0 + t0;
-                let t0 = x3 + t0;
-                let t2 = $name::mul_by_3b(&t2);
-                let z3 = t1 + t2;
-                let t1 = t1 - t2;
-                let y3 = $name::mul_by_3b(&y3);
-                let x3 = t4 * y3;
-                let t2 = t3 * t1;
-                let x3 = t2 - x3;
-                let y3 = y3 * t0;
-                let t1 = t1 * z3;
-                let y3 = t1 + y3;
-                let t0 = t0 * t3;
-                let z3 = z3 * t4;
+                let t5 = t5 - x3;
+                let z3 = $name::curve_constant_a() * t4;
+                let x3 = $name::mul_by_3b(&t2);
+                let z3 = x3 + z3;
+                let x3 = t1 - z3;
+                let z3 = t1 + z3;
+                let y3 = x3 * z3;
+                let t1 = t0 + t0;
+                let t1 = t1 + t0;
+                let t2 = $name::curve_constant_a() * t2;
+                let t4 = $name::mul_by_3b(&t4);
+                let t1 = t1 + t2;
+                let t2 = t0 - t2;
+                let t2 = $name::curve_constant_a() * t2;
+                let t4 = t4 + t2;
+                let t0 = t1 * t4;
+                let y3 = y3 + t0;
+                let t0 = t5 * t4;
+                let x3 = t3 * x3;
+                let x3 = x3 - t0;
+                let t0 = t3 * t1;
+                let z3 = t5 * z3;
                 let z3 = z3 + t0;
 
                 $name {
@@ -1059,8 +1088,7 @@ macro_rules! new_curve_impl {
 
             // Mixed addition
             fn add(self, rhs: &'a $name_affine) -> $name {
-                // Algorithm 8, https://eprint.iacr.org/2015/1060.pdf
-
+                // Algorithm 2, https://eprint.iacr.org/2015/1060.pdf
                 let t0 = self.x * rhs.x;
                 let t1 = self.y * rhs.y;
                 let t3 = rhs.x + rhs.y;
@@ -1068,24 +1096,31 @@ macro_rules! new_curve_impl {
                 let t3 = t3 * t4;
                 let t4 = t0 + t1;
                 let t3 = t3 - t4;
-                let t4 = rhs.y * self.z;
-                let t4 = t4 + self.y;
-                let y3 = rhs.x * self.z;
-                let y3 = y3 + self.x;
-                let x3 = t0 + t0;
-                let t0 = x3 + t0;
-                let t2 = $name::mul_by_3b(&self.z);
-                let z3 = t1 + t2;
-                let t1 = t1 - t2;
-                let y3 = $name::mul_by_3b(&y3);
-                let x3 = t4 * y3;
-                let t2 = t3 * t1;
-                let x3 = t2 - x3;
-                let y3 = y3 * t0;
-                let t1 = t1 * z3;
-                let y3 = t1 + y3;
-                let t0 = t0 * t3;
-                let z3 = z3 * t4;
+                let t4 = rhs.x * self.z;
+                let t4 = t4 + self.x;
+                let t5 = rhs.y * self.z;
+                let t5 = t5 + self.y;
+                let z3 = $name::curve_constant_a() * t4;
+                let x3 = $name::mul_by_3b(&self.z);
+                let z3 = x3 + z3;
+                let x3 = t1 - z3;
+                let z3 = t1 + z3;
+                let y3 = x3 * z3;
+                let t1 = t0 + t0;
+                let t1 = t1 + t0;
+                let t2 = $name::curve_constant_a() * self.z;
+                let t4 = $name::mul_by_3b(&t4);
+                let t1 = t1 + t2;
+                let t2 = t0 - t2;
+                let t2 = $name::curve_constant_a() * t2;
+                let t4 = t4 + t2;
+                let t0 = t1 * t4;
+                let y3 = y3 + t0;
+                let t0 = t5 * t4;
+                let x3 = t3 * x3;
+                let x3 = x3 - t0;
+                let t0 = t3 * t1;
+                let z3 = t5 * z3;
                 let z3 = z3 + t0;
 
                 let tmp = $name{

--- a/src/grumpkin/curve.rs
+++ b/src/grumpkin/curve.rs
@@ -28,6 +28,7 @@ new_curve_impl!(
     Fq,
     Fr,
     (G1_GENERATOR_X, G1_GENERATOR_Y),
+    G1_A,
     G1_B,
     "grumpkin_g1",
 );
@@ -49,6 +50,7 @@ const G1_GENERATOR_Y: Fq = Fq([
     0xaa7b8cf435dfafbb,
     0x14b34cf69dc25d68,
 ]);
+const G1_A: Fq = Fq::zero();
 const G1_B: Fq = Fq([
     0xdd7056026000005a,
     0x223fa97acb319311,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod grumpkin;
 pub mod pairing;
 pub mod pasta;
 pub mod secp256k1;
+pub mod secp256r1;
 pub mod serde;
 
 #[macro_use]

--- a/src/secp256r1/curve.rs
+++ b/src/secp256r1/curve.rs
@@ -1,8 +1,8 @@
 use crate::ff::WithSmallOrderMulGroup;
 use crate::ff::{Field, PrimeField};
 use crate::group::{prime::PrimeCurveAffine, Curve, Group as _, GroupEncoding};
-use crate::secp256k1::Fp;
-use crate::secp256k1::Fq;
+use crate::secp256r1::Fp;
+use crate::secp256r1::Fq;
 use crate::{Coordinates, CurveAffine, CurveAffineExt, CurveExt};
 use core::cmp;
 use core::fmt::Debug;
@@ -14,8 +14,8 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "derive_serde")]
 use serde::{Deserialize, Serialize};
 
-impl group::cofactor::CofactorGroup for Secp256k1 {
-    type Subgroup = Secp256k1;
+impl group::cofactor::CofactorGroup for Secp256r1 {
+    type Subgroup = Secp256r1;
 
     fn clear_cofactor(&self) -> Self {
         *self
@@ -30,22 +30,33 @@ impl group::cofactor::CofactorGroup for Secp256k1 {
     }
 }
 
-// Reference: https://neuromancer.sk/std/secg/secp256k1
+// Reference: https://neuromancer.sk/std/secg/secp256r1
 const SECP_GENERATOR_X: Fp = Fp::from_raw([
-    0x59F2815B16F81798,
-    0x029BFCDB2DCE28D9,
-    0x55A06295CE870B07,
-    0x79BE667EF9DCBBAC,
-]);
-const SECP_GENERATOR_Y: Fp = Fp::from_raw([
-    0x9C47D08FFB10D4B8,
-    0xFD17B448A6855419,
-    0x5DA4FBFC0E1108A8,
-    0x483ADA7726A3C465,
+    0xF4A13945D898C296,
+    0x77037D812DEB33A0,
+    0xF8BCE6E563A440F2,
+    0x6B17D1F2E12C4247,
 ]);
 
-const SECP_A: Fp = Fp::from_raw([0, 0, 0, 0]);
-const SECP_B: Fp = Fp::from_raw([7, 0, 0, 0]);
+const SECP_GENERATOR_Y: Fp = Fp::from_raw([
+    0xCBB6406837BF51F5,
+    0x2BCE33576B315ECE,
+    0x8EE7EB4A7C0F9E16,
+    0x4FE342E2FE1A7F9B,
+]);
+
+const SECP_A: Fp = Fp::from_raw([
+    0xFFFFFFFFFFFFFFFC,
+    0x00000000FFFFFFFF,
+    0x0000000000000000,
+    0xFFFFFFFF00000001,
+]);
+const SECP_B: Fp = Fp::from_raw([
+    0x3BCE3C3E27D2604B,
+    0x651D06B0CC53B0F6,
+    0xB3EBBD55769886BC,
+    0x5AC635D8AA3A93E7,
+]);
 
 use crate::{
     batch_add, impl_add_binop_specify_output, impl_binops_additive,
@@ -55,18 +66,18 @@ use crate::{
 
 new_curve_impl!(
     (pub),
-    Secp256k1,
-    Secp256k1Affine,
+    Secp256r1,
+    Secp256r1Affine,
     true,
     Fp,
     Fq,
     (SECP_GENERATOR_X,SECP_GENERATOR_Y),
     SECP_A,
     SECP_B,
-    "secp256k1",
+    "secp256r1",
 );
 
-impl CurveAffineExt for Secp256k1Affine {
+impl CurveAffineExt for Secp256r1Affine {
     batch_add!();
 
     fn into_coordinates(self) -> (Self::Base, Self::Base) {
@@ -76,20 +87,14 @@ impl CurveAffineExt for Secp256k1Affine {
 
 #[test]
 fn test_curve() {
-    crate::tests::curve::curve_tests::<Secp256k1>();
+    crate::tests::curve::curve_tests::<Secp256r1>();
 }
 
 #[test]
 fn test_serialization() {
-    crate::tests::curve::random_serialization_test::<Secp256k1>();
+    crate::tests::curve::random_serialization_test::<Secp256r1>();
     #[cfg(feature = "derive_serde")]
-    crate::tests::curve::random_serde_test::<Secp256k1>();
-}
-
-#[test]
-fn test_endo_consistency() {
-    let g = Secp256k1::generator();
-    assert_eq!(g * Fq::ZETA, g.endo());
+    crate::tests::curve::random_serde_test::<Secp256r1>();
 }
 
 #[test]
@@ -107,7 +112,7 @@ fn ecdsa_example() {
         Fq::from_uniform_bytes(&x_bytes)
     }
 
-    let g = Secp256k1::generator();
+    let g = Secp256r1::generator();
 
     for _ in 0..1000 {
         // Generate a key pair

--- a/src/secp256r1/fp.rs
+++ b/src/secp256r1/fp.rs
@@ -1,0 +1,380 @@
+use crate::arithmetic::{adc, mac, sbb};
+use crate::ff::{FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
+use core::convert::TryInto;
+use core::fmt;
+use core::ops::{Add, Mul, Neg, Sub};
+use rand::RngCore;
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+
+#[cfg(feature = "derive_serde")]
+use serde::{Deserialize, Serialize};
+
+/// This represents an element of $\mathbb{F}_p$ where
+///
+/// `p = 0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff
+///
+/// is the base field of the secp256r1 curve.
+// The internal representation of this type is four 64-bit unsigned
+// integers in little-endian order. `Fp` values are always in
+// Montgomery form; i.e., Fp(a) = aR mod p, with R = 2^256.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
+pub struct Fp(pub(crate) [u64; 4]);
+
+/// Constant representing the modulus
+/// p = 0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff
+const MODULUS: Fp = Fp([
+    0xffffffffffffffff,
+    0x00000000ffffffff,
+    0x0000000000000000,
+    0xffffffff00000001,
+]);
+
+/// Constant representing the multiplicative generator of the modulus.
+/// It's derived with SageMath with: `GF(MODULUS).primitive_element()`.
+const MULTIPLICATIVE_GENERATOR: Fp = Fp::from_raw([0x06, 0x00, 0x00, 0x00]);
+
+/// The modulus as u32 limbs.
+#[cfg(not(target_pointer_width = "64"))]
+const MODULUS_LIMBS_32: [u32; 8] = [
+    0xffff_ffff,
+    0xffff_ffff,
+    0xffff_ffff,
+    0x0000_0000,
+    0x0000_0000,
+    0x0000_0000,
+    0x0000_0001,
+    0xffff_ffff,
+];
+
+/// Constant representing the modolus as static str
+const MODULUS_STR: &str = "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff";
+
+/// INV = -(p^{-1} mod 2^64) mod 2^64
+const INV: u64 = 0x1;
+
+/// R = 2^256 mod p
+/// 0xfffffffeffffffffffffffffffffffff000000000000000000000001
+const R: Fp = Fp([
+    0x0000000000000001,
+    0xffffffff00000000,
+    0xffffffffffffffff,
+    0xfffffffe,
+]);
+
+/// R^2 = 2^512 mod p
+/// 0x4fffffffdfffffffffffffffefffffffbffffffff0000000000000003
+const R2: Fp = Fp([
+    0x0000000000000003,
+    0xfffffffbffffffff,
+    0xfffffffffffffffe,
+    0x4fffffffd,
+]);
+
+/// R^3 = 2^768 mod p
+/// 0x180000000100000005fffffffcffffffedfffffff7fffffffd0000000a
+const R3: Fp = Fp([
+    0xfffffffd0000000a,
+    0xffffffedfffffff7,
+    0x00000005fffffffc,
+    0x1800000001,
+]);
+
+/// 1 / 2 mod p
+/// 0x7fffffff80000000800000000000000000000000800000000000000000000000
+const TWO_INV: Fp = Fp::from_raw([
+    0x0000000000000000,
+    0x0000000080000000,
+    0x8000000000000000,
+    0x7fffffff80000000,
+]);
+
+const ZETA: Fp = Fp::from_raw([
+    0xd964598eb819acce,
+    0x2e68c59bdef3e53f,
+    0x62388a8e0ef62331,
+    0x4d6ea8928adb86cf,
+]);
+
+/// Generator of the t-order multiplicative subgroup.
+/// Computed by exponentiating Self::MULTIPLICATIVE_GENERATOR by 2^s, where s is Self::S.
+/// `0x0000000000000000000000000000000000000000000000000000000000000024`.
+const DELTA: Fp = Fp::from_raw([0x24, 0, 0, 0]);
+
+/// Implementations of this trait MUST ensure that this is the generator used to derive Self::ROOT_OF_UNITY.
+/// Derived from:
+/// ```ignore
+/// Zp(Zp(mul_generator)^t) where t = (modulus - 1 )/ 2
+/// 115792089237316195423570985008687907853269984665640564039457584007908834671662
+/// ```
+/// `0xffffffff00000001000000000000000000000000fffffffffffffffffffffffe`
+const ROOT_OF_UNITY: Fp = Fp::from_raw([
+    0xfffffffffffffffe,
+    0x00000000ffffffff,
+    0x0000000000000000,
+    0xffffffff00000001,
+]);
+
+/// Inverse of [`ROOT_OF_UNITY`].
+/// `0xffffffff00000001000000000000000000000000fffffffffffffffffffffffe`
+const ROOT_OF_UNITY_INV: Fp = Fp::from_raw([
+    0xfffffffffffffffe,
+    0x00000000ffffffff,
+    0x0000000000000000,
+    0xffffffff00000001,
+]);
+
+use crate::{
+    field_arithmetic, field_common, field_specific, impl_add_binop_specify_output,
+    impl_binops_additive, impl_binops_additive_specify_output, impl_binops_multiplicative,
+    impl_binops_multiplicative_mixed, impl_sub_binop_specify_output, impl_sum_prod,
+};
+impl_binops_additive!(Fp, Fp);
+impl_binops_multiplicative!(Fp, Fp);
+field_common!(
+    Fp,
+    MODULUS,
+    INV,
+    MODULUS_STR,
+    TWO_INV,
+    ROOT_OF_UNITY_INV,
+    DELTA,
+    ZETA,
+    R,
+    R2,
+    R3
+);
+field_arithmetic!(Fp, MODULUS, INV, dense);
+impl_sum_prod!(Fp);
+
+impl Fp {
+    pub const fn size() -> usize {
+        32
+    }
+}
+
+impl ff::Field for Fp {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+
+    fn random(mut rng: impl RngCore) -> Self {
+        Self::from_u512([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ])
+    }
+
+    fn double(&self) -> Self {
+        self.double()
+    }
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        self.square()
+    }
+
+    /// Computes the square root of this element, if it exists.
+    fn sqrt(&self) -> CtOption<Self> {
+        let tmp = self.pow(&[
+            0x0000000000000000,
+            0x0000000040000000,
+            0x4000000000000000,
+            0x3fffffffc0000000,
+        ]);
+
+        CtOption::new(tmp, tmp.square().ct_eq(self))
+    }
+
+    /// Computes the multiplicative inverse of this element,
+    /// failing if the element is zero.
+    fn invert(&self) -> CtOption<Self> {
+        let tmp = self.pow_vartime(&[
+            0xfffffffffffffffd,
+            0x00000000ffffffff,
+            0x0000000000000000,
+            0xffffffff00000001,
+        ]);
+
+        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
+    }
+
+    fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
+        let mut res = Self::one();
+        let mut found_one = false;
+        for e in exp.as_ref().iter().rev() {
+            for i in (0..64).rev() {
+                if found_one {
+                    res = res.square();
+                }
+
+                if ((*e >> i) & 1) == 1 {
+                    found_one = true;
+                    res *= self;
+                }
+            }
+        }
+        res
+    }
+
+    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+        ff::helpers::sqrt_ratio_generic(num, div)
+    }
+}
+
+impl ff::PrimeField for Fp {
+    type Repr = [u8; 32];
+
+    const MODULUS: &'static str = MODULUS_STR;
+    const MULTIPLICATIVE_GENERATOR: Self = MULTIPLICATIVE_GENERATOR;
+    const TWO_INV: Self = TWO_INV;
+    const ROOT_OF_UNITY: Self = ROOT_OF_UNITY;
+    const ROOT_OF_UNITY_INV: Self = ROOT_OF_UNITY_INV;
+    const DELTA: Self = DELTA;
+    const NUM_BITS: u32 = 256;
+    const CAPACITY: u32 = 255;
+    const S: u32 = 1;
+
+    fn from_repr(repr: Self::Repr) -> CtOption<Self> {
+        let mut tmp = Fp([0, 0, 0, 0]);
+
+        tmp.0[0] = u64::from_le_bytes(repr[0..8].try_into().unwrap());
+        tmp.0[1] = u64::from_le_bytes(repr[8..16].try_into().unwrap());
+        tmp.0[2] = u64::from_le_bytes(repr[16..24].try_into().unwrap());
+        tmp.0[3] = u64::from_le_bytes(repr[24..32].try_into().unwrap());
+
+        // Try to subtract the modulus
+        let (_, borrow) = sbb(tmp.0[0], MODULUS.0[0], 0);
+        let (_, borrow) = sbb(tmp.0[1], MODULUS.0[1], borrow);
+        let (_, borrow) = sbb(tmp.0[2], MODULUS.0[2], borrow);
+        let (_, borrow) = sbb(tmp.0[3], MODULUS.0[3], borrow);
+
+        // If the element is smaller than MODULUS then the
+        // subtraction will underflow, producing a borrow value
+        // of 0xffff...ffff. Otherwise, it'll be zero.
+        let is_some = (borrow as u8) & 1;
+
+        // Convert to Montgomery form by computing
+        // (a.R^0 * R^2) / R = a.R
+        tmp *= &R2;
+
+        CtOption::new(tmp, Choice::from(is_some))
+    }
+
+    fn to_repr(&self) -> Self::Repr {
+        // Turn into canonical form by computing
+        // (a.R) / R = a
+        let tmp = Fp::montgomery_reduce(&[self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0]);
+
+        let mut res = [0; 32];
+        res[0..8].copy_from_slice(&tmp.0[0].to_le_bytes());
+        res[8..16].copy_from_slice(&tmp.0[1].to_le_bytes());
+        res[16..24].copy_from_slice(&tmp.0[2].to_le_bytes());
+        res[24..32].copy_from_slice(&tmp.0[3].to_le_bytes());
+
+        res
+    }
+
+    fn from_u128(v: u128) -> Self {
+        Self::from_raw([v as u64, (v >> 64) as u64, 0, 0])
+    }
+
+    fn is_odd(&self) -> Choice {
+        Choice::from(self.to_repr()[0] & 1)
+    }
+}
+
+impl FromUniformBytes<64> for Fp {
+    /// Converts a 512-bit little endian integer into
+    /// an `Fp` by reducing by the modulus.
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+        Self::from_u512([
+            u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+            u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+            u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+            u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
+            u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
+            u64::from_le_bytes(bytes[48..56].try_into().unwrap()),
+            u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
+        ])
+    }
+}
+
+impl WithSmallOrderMulGroup<3> for Fp {
+    const ZETA: Self = ZETA;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ff::Field;
+    use rand_core::OsRng;
+
+    #[test]
+    fn test_sqrt() {
+        // NB: TWO_INV is standing in as a "random" field element
+        let v = (Fp::TWO_INV).square().sqrt().unwrap();
+        assert!(v == Fp::TWO_INV || (-v) == Fp::TWO_INV);
+
+        for _ in 0..10000 {
+            let a = Fp::random(OsRng);
+            let mut b = a;
+            b = b.square();
+
+            let b = b.sqrt().unwrap();
+            let mut negb = b;
+            negb = negb.neg();
+
+            assert!(a == b || a == negb);
+        }
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(
+            Fp::MODULUS,
+            "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+        );
+
+        assert_eq!(Fp::from(2) * Fp::TWO_INV, Fp::ONE);
+    }
+
+    #[test]
+    fn test_delta() {
+        assert_eq!(
+            Fp::DELTA,
+            MULTIPLICATIVE_GENERATOR.pow(&[1u64 << Fp::S, 0, 0, 0])
+        );
+    }
+
+    #[test]
+    fn test_root_of_unity() {
+        assert_eq!(
+            Fp::ROOT_OF_UNITY.pow_vartime(&[1 << Fp::S, 0, 0, 0]),
+            Fp::one()
+        );
+    }
+
+    #[test]
+    fn test_inv_root_of_unity() {
+        assert_eq!(Fp::ROOT_OF_UNITY_INV, Fp::ROOT_OF_UNITY.invert().unwrap());
+    }
+
+    #[test]
+    fn test_field() {
+        crate::tests::field::random_field_tests::<Fp>("secp256r1 base".to_string());
+    }
+
+    #[test]
+    fn test_serialization() {
+        crate::tests::field::random_serialization_test::<Fp>("secp256r1 base".to_string());
+        #[cfg(feature = "derive_serde")]
+        crate::tests::field::random_serde_test::<Fp>("secp256r1 base".to_string());
+    }
+}

--- a/src/secp256r1/fq.rs
+++ b/src/secp256r1/fq.rs
@@ -1,0 +1,376 @@
+use crate::arithmetic::{adc, mac, sbb};
+use crate::ff::{FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
+use core::convert::TryInto;
+use core::fmt;
+use core::ops::{Add, Mul, Neg, Sub};
+use rand::RngCore;
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+
+#[cfg(feature = "derive_serde")]
+use serde::{Deserialize, Serialize};
+
+/// This represents an element of $\mathbb{F}_q$ where
+///
+/// `q = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551`
+///
+/// is the scalar field of the secp256r1 curve.
+// The internal representation of this type is four 64-bit unsigned
+// integers in little-endian order. `Fq` values are always in
+// Montgomery form; i.e., Fq(a) = aR mod q, with R = 2^256.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
+pub struct Fq(pub(crate) [u64; 4]);
+
+/// Constant representing the modulus
+/// q = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
+const MODULUS: Fq = Fq([
+    0xf3b9cac2fc632551,
+    0xbce6faada7179e84,
+    0xffffffffffffffff,
+    0xffffffff00000000,
+]);
+
+/// The modulus as u32 limbs.
+#[cfg(not(target_pointer_width = "64"))]
+const MODULUS_LIMBS_32: [u32; 8] = [
+    0xfc63_2551,
+    0xf3b9_cac2,
+    0xa717_9e84,
+    0xbce6_faad,
+    0xffff_ffff,
+    0xffff_ffff,
+    0x0000_0000,
+    0xffff_ffff,
+];
+
+///Constant representing the modulus as static str
+const MODULUS_STR: &str = "0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551";
+
+/// INV = -(q^{-1} mod 2^64) mod 2^64
+const INV: u64 = 0xccd1c8aaee00bc4f;
+
+/// R = 2^256 mod q
+/// 0xffffffff00000000000000004319055258e8617b0c46353d039cdaaf
+const R: Fq = Fq([
+    0x0c46353d039cdaaf,
+    0x4319055258e8617b,
+    0x0000000000000000,
+    0xffffffff,
+]);
+
+/// R^2 = 2^512 mod q
+/// 0x66e12d94f3d956202845b2392b6bec594699799c49bd6fa683244c95be79eea2
+const R2: Fq = Fq([
+    0x83244c95be79eea2,
+    0x4699799c49bd6fa6,
+    0x2845b2392b6bec59,
+    0x66e12d94f3d95620,
+]);
+
+/// R^3 = 2^768 mod q
+/// 0x503a54e76407be652543b9246ba5e93f111f28ae0c0555c9ac8ebec90b65a624
+const R3: Fq = Fq([
+    0xac8ebec90b65a624,
+    0x111f28ae0c0555c9,
+    0x2543b9246ba5e93f,
+    0x503a54e76407be65,
+]);
+
+/// `GENERATOR = 7 mod r` is a generator of the `q - 1` order multiplicative
+/// subgroup, or in other words a primitive root of the field.
+/// It's derived with SageMath with: `GF(MODULUS).primitive_element()`.
+const GENERATOR: Fq = Fq::from_raw([0x07, 0x00, 0x00, 0x00]);
+
+/// GENERATOR^t where t * 2^s + 1 = r with t odd. In other words, this is a 2^s root of unity.
+/// `ffc97f062a770992ba807ace842a3dfc1546cad004378daf0592d7fbb41e6602`
+const ROOT_OF_UNITY: Fq = Fq::from_raw([
+    0x0592d7fbb41e6602,
+    0x1546cad004378daf,
+    0xba807ace842a3dfc,
+    0xffc97f062a770992,
+]);
+
+/// 1 / ROOT_OF_UNITY mod q
+/// `a0a66a5562d46f2ac645fa0458131caee3ac117c794c4137379c7f0657c73764`
+const ROOT_OF_UNITY_INV: Fq = Fq::from_raw([
+    0x379c7f0657c73764,
+    0xe3ac117c794c4137,
+    0xc645fa0458131cae,
+    0xa0a66a5562d46f2a,
+]);
+
+/// 1 / 2 mod q
+const TWO_INV: Fq = Fq::from_raw([
+    0x79dce5617e3192a9,
+    0xde737d56d38bcf42,
+    0x7fffffffffffffff,
+    0x7fffffff80000000,
+]);
+
+const ZETA: Fq = Fq::from_raw([
+    0x7cbf87ff12884e21,
+    0x9405335ce9c83e1d,
+    0x4e786d0777fd6aef,
+    0x52891d43d946a035,
+]);
+
+/// Generator of the t-order multiplicative subgroup.
+/// Computed by exponentiating Self::MULTIPLICATIVE_GENERATOR by 2^s, where s is Self::S.
+/// `0x1e39a5057d81`
+const DELTA: Fq = Fq::from_raw([0x1e39a5057d81, 0, 0, 0]);
+
+use crate::{
+    field_arithmetic, field_common, field_specific, impl_add_binop_specify_output,
+    impl_binops_additive, impl_binops_additive_specify_output, impl_binops_multiplicative,
+    impl_binops_multiplicative_mixed, impl_sub_binop_specify_output, impl_sum_prod,
+};
+impl_binops_additive!(Fq, Fq);
+impl_binops_multiplicative!(Fq, Fq);
+field_common!(
+    Fq,
+    MODULUS,
+    INV,
+    MODULUS_STR,
+    TWO_INV,
+    ROOT_OF_UNITY_INV,
+    DELTA,
+    ZETA,
+    R,
+    R2,
+    R3
+);
+field_arithmetic!(Fq, MODULUS, INV, dense);
+impl_sum_prod!(Fq);
+
+impl Fq {
+    pub const fn size() -> usize {
+        32
+    }
+}
+
+impl ff::Field for Fq {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+
+    fn random(mut rng: impl RngCore) -> Self {
+        Self::from_u512([
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ])
+    }
+
+    fn double(&self) -> Self {
+        self.double()
+    }
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        self.square()
+    }
+
+    /// Computes the multiplicative inverse of this element,
+    /// failing if the element is zero.
+    fn invert(&self) -> CtOption<Self> {
+        let tmp = self.pow_vartime(&[
+            0xf3b9cac2fc63254f,
+            0xbce6faada7179e84,
+            0xffffffffffffffff,
+            0xffffffff00000000,
+        ]);
+
+        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
+    }
+
+    fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
+        let mut res = Self::one();
+        let mut found_one = false;
+        for e in exp.as_ref().iter().rev() {
+            for i in (0..64).rev() {
+                if found_one {
+                    res = res.square();
+                }
+
+                if ((*e >> i) & 1) == 1 {
+                    found_one = true;
+                    res *= self;
+                }
+            }
+        }
+        res
+    }
+
+    fn sqrt(&self) -> CtOption<Self> {
+        let tm1d2 = [
+            0x279dce5617e3192a,
+            0xfde737d56d38bcf4,
+            0x07ffffffffffffff,
+            0x07fffffff8000000,
+        ];
+
+        ff::helpers::sqrt_tonelli_shanks(self, &tm1d2)
+    }
+
+    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+        ff::helpers::sqrt_ratio_generic(num, div)
+    }
+}
+
+impl ff::PrimeField for Fq {
+    type Repr = [u8; 32];
+
+    const NUM_BITS: u32 = 256;
+    const CAPACITY: u32 = 255;
+    const MODULUS: &'static str = MODULUS_STR;
+    const MULTIPLICATIVE_GENERATOR: Self = GENERATOR;
+    const ROOT_OF_UNITY: Self = ROOT_OF_UNITY;
+    const ROOT_OF_UNITY_INV: Self = ROOT_OF_UNITY_INV;
+    const TWO_INV: Self = TWO_INV;
+    const DELTA: Self = DELTA;
+    const S: u32 = 4;
+
+    fn from_repr(repr: Self::Repr) -> CtOption<Self> {
+        let mut tmp = Fq([0, 0, 0, 0]);
+
+        tmp.0[0] = u64::from_le_bytes(repr[0..8].try_into().unwrap());
+        tmp.0[1] = u64::from_le_bytes(repr[8..16].try_into().unwrap());
+        tmp.0[2] = u64::from_le_bytes(repr[16..24].try_into().unwrap());
+        tmp.0[3] = u64::from_le_bytes(repr[24..32].try_into().unwrap());
+
+        // Try to subtract the modulus
+        let (_, borrow) = sbb(tmp.0[0], MODULUS.0[0], 0);
+        let (_, borrow) = sbb(tmp.0[1], MODULUS.0[1], borrow);
+        let (_, borrow) = sbb(tmp.0[2], MODULUS.0[2], borrow);
+        let (_, borrow) = sbb(tmp.0[3], MODULUS.0[3], borrow);
+
+        // If the element is smaller than MODULUS then the
+        // subtraction will underflow, producing a borrow value
+        // of 0xffff...ffff. Otherwise, it'll be zero.
+        let is_some = (borrow as u8) & 1;
+
+        // Convert to Montgomery form by computi
+        // (a.R^0 * R^2) / R = a.R
+        tmp *= &R2;
+
+        CtOption::new(tmp, Choice::from(is_some))
+    }
+
+    fn to_repr(&self) -> Self::Repr {
+        // Turn into canonical form by computing
+        // (a.R) / R = a
+        let tmp = Fq::montgomery_reduce(&[self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0]);
+
+        let mut res = [0; 32];
+        res[0..8].copy_from_slice(&tmp.0[0].to_le_bytes());
+        res[8..16].copy_from_slice(&tmp.0[1].to_le_bytes());
+        res[16..24].copy_from_slice(&tmp.0[2].to_le_bytes());
+        res[24..32].copy_from_slice(&tmp.0[3].to_le_bytes());
+
+        res
+    }
+
+    fn is_odd(&self) -> Choice {
+        Choice::from(self.to_repr()[0] & 1)
+    }
+}
+
+impl FromUniformBytes<64> for Fq {
+    /// Converts a 512-bit little endian integer into
+    /// an `Fq` by reducing by the modulus.
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+        Self::from_u512([
+            u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+            u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+            u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+            u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
+            u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
+            u64::from_le_bytes(bytes[48..56].try_into().unwrap()),
+            u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
+        ])
+    }
+}
+
+impl WithSmallOrderMulGroup<3> for Fq {
+    const ZETA: Self = ZETA;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ff::Field;
+    use rand_core::OsRng;
+
+    #[test]
+    fn test_zeta() {
+        assert_eq!(Fq::ZETA * Fq::ZETA * Fq::ZETA, Fq::ONE);
+        assert_ne!(Fq::ZETA * Fq::ZETA, Fq::ONE);
+    }
+
+    #[test]
+    fn test_sqrt() {
+        // NB: TWO_INV is standing in as a "random" field element
+        let v = (Fq::TWO_INV).square().sqrt().unwrap();
+        assert!(v == Fq::TWO_INV || (-v) == Fq::TWO_INV);
+
+        for _ in 0..10000 {
+            let a = Fq::random(OsRng);
+            let mut b = a;
+            b = b.square();
+
+            let b = b.sqrt().unwrap();
+            let mut negb = b;
+            negb = negb.neg();
+
+            assert!(a == b || a == negb);
+        }
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(
+            Fq::MODULUS,
+            "0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+        );
+
+        assert_eq!(Fq::from(2) * Fq::TWO_INV, Fq::ONE);
+    }
+
+    #[test]
+    fn test_delta() {
+        assert_eq!(
+            Fq::DELTA,
+            Fq::MULTIPLICATIVE_GENERATOR.pow(&[1u64 << Fq::S, 0, 0, 0])
+        );
+    }
+
+    #[test]
+    fn test_root_of_unity() {
+        assert_eq!(
+            Fq::ROOT_OF_UNITY.pow_vartime(&[1 << Fq::S, 0, 0, 0]),
+            Fq::one()
+        );
+    }
+
+    #[test]
+    fn test_inv_root_of_unity() {
+        assert_eq!(Fq::ROOT_OF_UNITY_INV, Fq::ROOT_OF_UNITY.invert().unwrap());
+    }
+
+    #[test]
+    fn test_field() {
+        crate::tests::field::random_field_tests::<Fq>("secp256r1 scalar".to_string());
+    }
+
+    #[test]
+    fn test_serialization() {
+        crate::tests::field::random_serialization_test::<Fq>("secp256r1 scalar".to_string());
+        #[cfg(feature = "derive_serde")]
+        crate::tests::field::random_serde_test::<Fq>("secp256r1 scalar".to_string());
+    }
+}

--- a/src/secp256r1/fq.rs
+++ b/src/secp256r1/fq.rs
@@ -122,7 +122,7 @@ const DELTA: Fq = Fq::from_raw([0x1e39a5057d81, 0, 0, 0]);
 use crate::{
     field_arithmetic, field_common, field_specific, impl_add_binop_specify_output,
     impl_binops_additive, impl_binops_additive_specify_output, impl_binops_multiplicative,
-    impl_binops_multiplicative_mixed, impl_sub_binop_specify_output, impl_sum_prod,
+    impl_binops_multiplicative_mixed, impl_sub_binop_specify_output, impl_sum_prod, impl_from_u64,
 };
 impl_binops_additive!(Fq, Fq);
 impl_binops_multiplicative!(Fq, Fq);
@@ -139,6 +139,7 @@ field_common!(
     R2,
     R3
 );
+impl_from_u64!(Fq, R2);
 field_arithmetic!(Fq, MODULUS, INV, dense);
 impl_sum_prod!(Fq);
 

--- a/src/secp256r1/mod.rs
+++ b/src/secp256r1/mod.rs
@@ -1,0 +1,7 @@
+mod curve;
+mod fp;
+mod fq;
+
+pub use curve::*;
+pub use fp::*;
+pub use fq::*;


### PR DESCRIPTION
Adds new directory `secp256r1` that adds the [NIST P-256](https://neuromancer.sk/std/nist/P-256) curve and its relevant arithmetic operations.

To do this, also modified the macros in `src/derive/curve.rs` to account for curves where `a ≠ 0`. Because `bn256` and `secp256k1` both have `a = 0`, the elliptic curve operations (`add()`, `double()`, `is_on_curve()`, etc) used calculations that made this assumption. Since `secp256r1` has `a = 0xfff...fffc`, these operations needed to be refactored.

Tests mirror those of the `secp256k1` curve. Additionally added a test that checks the ZETA value of the curve.

Thank you to @CPerezz for helping me debug the tests and @enricobottazzi for investigating this library!