### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves"
-version = "0.3.2"
+version = "0.3.3"
 authors = [
   "Sean Bowe <ewillbefull@gmail.com>",
   "Jack Grigg <jack@z.cash>",


### PR DESCRIPTION
Allows us to use the most recent changes in Halo2 :)

I'm not sure how the tag is created, does that happen automatically?