### PR TITLE
Implement `CurveExt::hash_to_curve` for `{bn256::G1,grumpkin::G1}`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.63.0
-            feature: default
-          - rust: nightly
-            feature: asm
-
+          - feature: default
+          - feature: asm
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          toolchain: ${{ matrix.rust }}
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -37,17 +31,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.63.0
-            feature: default
-          - rust: nightly
-            feature: asm
-
+          - feature: default
+          - feature: asm
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          toolchain: ${{ matrix.rust }}
       - name: Test
         uses: actions-rs/cargo@v1
         with:
@@ -79,8 +67,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          override: true
-          toolchain: nightly
           components: clippy
       - name: Run clippy
         uses: actions-rs/cargo@v1
@@ -96,9 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          toolchain: nightly
       - name: Bench arithmetic
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ num-traits = "0.2"
 paste = "1.0.11"
 serde = { version = "1.0", default-features = false, optional = true }
 serde_arrays = { version = "0.1.0", optional = true }
+blake2b_simd = "1"
 
 [features]
 default = ["reexport", "bits"]

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -10,6 +10,7 @@ use crate::ff::WithSmallOrderMulGroup;
 use crate::ff::{Field, PrimeField};
 use crate::group::Curve;
 use crate::group::{cofactor::CofactorGroup, prime::PrimeCurveAffine, Group, GroupEncoding};
+use crate::hash_to_curve::svdw_map_to_curve;
 use crate::{
     batch_add, impl_add_binop_specify_output, impl_binops_additive,
     impl_binops_additive_specify_output, impl_binops_multiplicative,
@@ -38,6 +39,7 @@ new_curve_impl!(
     G1_A,
     G1_B,
     "bn256_g1",
+    |curve_id, domain_prefix| svdw_map_to_curve(curve_id, domain_prefix, Fq::ONE),
 );
 
 new_curve_impl!(
@@ -51,6 +53,7 @@ new_curve_impl!(
     G2_A,
     G2_B,
     "bn256_g2",
+    |_, _| unimplemented!(),
 );
 
 impl CurveAffineExt for G1Affine {
@@ -222,6 +225,11 @@ mod tests {
     use ff::PrimeField;
     use ff::WithSmallOrderMulGroup;
     use rand_core::OsRng;
+
+    #[test]
+    fn test_hash_to_curve() {
+        crate::tests::curve::hash_to_curve_test::<G1>();
+    }
 
     #[test]
     fn test_curve() {

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -219,16 +219,136 @@ impl CofactorGroup for G2 {
 mod tests {
 
     use crate::arithmetic::CurveEndo;
-    use crate::bn256::{Fr, G1, G2};
+    use crate::bn256::{Fq, Fr, G1Affine, G1, G2};
+    use crate::hash_to_curve::map_to_curve;
+    use crate::serde::SerdeObject;
     use crate::CurveExt;
     use ff::Field;
-    use ff::PrimeField;
-    use ff::WithSmallOrderMulGroup;
+    use ff::{PrimeField, WithSmallOrderMulGroup};
+    use group::Curve;
+    use num_bigint::BigUint;
+    use num_traits::Num;
+    use pasta_curves::arithmetic::CurveAffine;
     use rand_core::OsRng;
 
     #[test]
     fn test_hash_to_curve() {
         crate::tests::curve::hash_to_curve_test::<G1>();
+    }
+
+    #[test]
+    fn test_map_to_curve_bn256() {
+        // from https://github.com/ConsenSys/gnark-crypto/blob/master/ecc/bn254/hash_vectors_test.go
+        let encode_tests = vec![
+            (
+                //u
+                "0xcb81538a98a2e3580076eed495256611813f6dae9e16d3d4f8de7af0e9833e1",
+                // Q
+                (
+                    "0x1bb8810e2ceaf04786d4efd216fc2820ddd9363712efc736ada11049d8af5925",
+                    "0x1efbf8d54c60d865cce08437668ea30f5bf90d287dbd9b5af31da852915e8f11",
+                ),
+            ),
+            (
+                //u
+                "0xba35e127276e9000b33011860904ddee28f1d48ddd3577e2a797ef4a5e62319",
+                // Q
+                (
+                    "0xda4a96147df1f35b0f820bd35c6fac3b80e8e320de7c536b1e054667b22c332",
+                    "0x189bd3fbffe4c8740d6543754d95c790e44cd2d162858e3b733d2b8387983bb7",
+                ),
+            ),
+            (
+                //u
+                "0x11852286660cd970e9d7f46f99c7cca2b75554245e91b9b19d537aa6147c28fc",
+                // Q
+                (
+                    "0x2ff727cfaaadb3acab713fa22d91f5fddab3ed77948f3ef6233d7ea9b03f4da1",
+                    "0x304080768fd2f87a852155b727f97db84b191e41970506f0326ed4046d1141aa",
+                ),
+            ),
+            (
+                //u
+                "0x174d1c85d8a690a876cc1deba0166d30569fafdb49cb3ed28405bd1c5357a1cc",
+                // Q
+                (
+                    "0x11a2eaa8e3e89de056d1b3a288a7f733c8a1282efa41d28e71af065ab245df9b",
+                    "0x60f37c447ac29fd97b9bb83be98ddccf15e34831a9cdf5493b7fede0777ae06",
+                ),
+            ),
+            (
+                //u
+                "0x73b81432b4cf3a8a9076201500d1b94159539f052a6e0928db7f2df74bff672",
+                // Q
+                (
+                    "0x27409dccc6ee4ce90e24744fda8d72c0bc64e79766f778da0c1c0ef1c186ea84",
+                    "0x1ac201a542feca15e77f30370da183514dc99d8a0b2c136d64ede35cd0b51dc0",
+                ),
+            ),
+        ];
+
+        // inspired by TestMapToCurve1 in
+        // https://github.com/ConsenSys/gnark-crypto/blob/master/ecc/bn254/hash_to_g1_test.go
+        for (u, pt_q) in encode_tests {
+            let big_u = BigUint::from_str_radix(&u.strip_prefix("0x").unwrap(), 16)
+                .unwrap()
+                .to_string();
+            let u = Fq::from_str_vartime(&big_u).unwrap();
+
+            println!("{:x?}", u);
+
+            let to_fq = |arg: [u64; 4]| {
+                let arg_bytes: [u8; 32] = unsafe { ::std::mem::transmute(arg) };
+                Fq::from_raw_bytes_unchecked(&arg_bytes)
+            };
+
+            // from https://github.com/ConsenSys/gnark-crypto/blob/master/ecc/bn254/hash_to_g1.go
+            let z = to_fq([
+                15230403791020821917,
+                754611498739239741,
+                7381016538464732716,
+                1011752739694698287,
+            ]);
+            let c1 = to_fq([
+                1248766071674976557,
+                10548065924188627562,
+                16242874202584236114,
+                560012691975822483,
+            ]);
+            let c2 = to_fq([
+                12997850613838968789,
+                14304628359724097447,
+                2950087706404981016,
+                1237622763554136189,
+            ]);
+            let c3 = to_fq([
+                8972444824031832946,
+                5898165201680709844,
+                10690697896010808308,
+                824354360198587078,
+            ]);
+            let c4 = to_fq([
+                12077013577332951089,
+                1872782865047492001,
+                13514471836495169457,
+                415649166299893576,
+            ]);
+
+            let g: G1 = map_to_curve(u, &c1, c2, &c3, &c4, &G1::a(), &G1::b(), &z);
+            let g_aff = g.to_affine();
+
+            let big_x = BigUint::from_str_radix(&pt_q.0.strip_prefix("0x").unwrap(), 16)
+                .unwrap()
+                .to_string();
+            let big_y = BigUint::from_str_radix(&pt_q.1.strip_prefix("0x").unwrap(), 16)
+                .unwrap()
+                .to_string();
+            let x = Fq::from_str_vartime(&big_x).unwrap();
+            let y = Fq::from_str_vartime(&big_y).unwrap();
+            let expected_g = G1Affine::from_xy(x, y).unwrap();
+
+            assert_eq!(g_aff, expected_g);
+        }
     }
 
     #[test]

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -295,8 +295,6 @@ mod tests {
                 .to_string();
             let u = Fq::from_str_vartime(&big_u).unwrap();
 
-            println!("{:x?}", u);
-
             let to_fq = |arg: [u64; 4]| {
                 let arg_bytes: [u8; 32] = unsafe { ::std::mem::transmute(arg) };
                 Fq::from_raw_bytes_unchecked(&arg_bytes)

--- a/src/bn256/engine.rs
+++ b/src/bn256/engine.rs
@@ -62,7 +62,7 @@ pub struct Gt(pub(crate) Fq12);
 
 impl std::fmt::Display for Gt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -463,8 +463,8 @@ mod test {
         let mut rng = ark_std::test_rng();
         let base = (0..repeat).map(|_| (rng.next_u32() % (1 << 16)) as u64);
 
-        let timer = start_timer!(|| format!("generate {} Bn256 scalar field elements", repeat));
-        let _res: Vec<_> = base.map(|b| Fr::from(b)).collect();
+        let timer = start_timer!(|| format!("generate {repeat} Bn256 scalar field elements"));
+        let _res: Vec<_> = base.map(Fr::from).collect();
 
         end_timer!(timer);
     }

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -203,6 +203,7 @@ macro_rules! new_curve_impl {
     $constant_a:expr,
     $constant_b:expr,
     $curve_id:literal,
+    $hash_to_curve:expr,
     ) => {
 
         macro_rules! impl_compressed {
@@ -615,8 +616,8 @@ macro_rules! new_curve_impl {
             }
 
 
-            fn hash_to_curve<'a>(_: &'a str) -> Box<dyn Fn(&[u8]) -> Self + 'a> {
-                unimplemented!();
+            fn hash_to_curve<'a>(domain_prefix: &'a str) -> Box<dyn Fn(&[u8]) -> Self + 'a> {
+                $hash_to_curve($curve_id, domain_prefix)
             }
 
             fn is_on_curve(&self) -> Choice {

--- a/src/grumpkin/curve.rs
+++ b/src/grumpkin/curve.rs
@@ -4,7 +4,7 @@ use crate::group::Curve;
 use crate::group::{prime::PrimeCurveAffine, Group, GroupEncoding};
 use crate::grumpkin::Fq;
 use crate::grumpkin::Fr;
-use crate::hash_to_curve::svdw_map_to_curve;
+use crate::hash_to_curve::svdw_hash_to_curve;
 use crate::{
     batch_add, impl_add_binop_specify_output, impl_binops_additive,
     impl_binops_additive_specify_output, impl_binops_multiplicative,
@@ -32,7 +32,7 @@ new_curve_impl!(
     G1_A,
     G1_B,
     "grumpkin_g1",
-    |curve_id, domain_prefix| svdw_map_to_curve(curve_id, domain_prefix, Fq::ONE),
+    |curve_id, domain_prefix| svdw_hash_to_curve(curve_id, domain_prefix, G1::SVDW_Z),
 );
 
 impl CurveAffineExt for G1Affine {
@@ -74,6 +74,10 @@ impl group::cofactor::CofactorGroup for G1 {
     fn is_torsion_free(&self) -> Choice {
         1.into()
     }
+}
+
+impl G1 {
+    const SVDW_Z: Fq = Fq::ONE;
 }
 
 #[cfg(test)]

--- a/src/grumpkin/curve.rs
+++ b/src/grumpkin/curve.rs
@@ -4,6 +4,7 @@ use crate::group::Curve;
 use crate::group::{prime::PrimeCurveAffine, Group, GroupEncoding};
 use crate::grumpkin::Fq;
 use crate::grumpkin::Fr;
+use crate::hash_to_curve::svdw_map_to_curve;
 use crate::{
     batch_add, impl_add_binop_specify_output, impl_binops_additive,
     impl_binops_additive_specify_output, impl_binops_multiplicative,
@@ -31,6 +32,7 @@ new_curve_impl!(
     G1_A,
     G1_B,
     "grumpkin_g1",
+    |curve_id, domain_prefix| svdw_map_to_curve(curve_id, domain_prefix, Fq::ONE),
 );
 
 impl CurveAffineExt for G1Affine {
@@ -79,6 +81,11 @@ mod tests {
     use crate::grumpkin::{Fr, G1};
     use crate::CurveExt;
     use ff::WithSmallOrderMulGroup;
+
+    #[test]
+    fn test_hash_to_curve() {
+        crate::tests::curve::hash_to_curve_test::<G1>();
+    }
 
     #[test]
     fn test_curve() {

--- a/src/hash_to_curve.rs
+++ b/src/hash_to_curve.rs
@@ -1,0 +1,200 @@
+#![allow(clippy::op_ref)]
+
+use ff::{Field, FromUniformBytes, PrimeField};
+use pasta_curves::arithmetic::CurveExt;
+use static_assertions::const_assert;
+use subtle::{ConditionallySelectable, ConstantTimeEq};
+
+/// Hashes over a message and writes the output to all of `buf`.
+/// Modified from https://github.com/zcash/pasta_curves/blob/7e3fc6a4919f6462a32b79dd226cb2587b7961eb/src/hashtocurve.rs#L11.
+fn hash_to_field<F: FromUniformBytes<64>>(
+    method: &str,
+    curve_id: &str,
+    domain_prefix: &str,
+    message: &[u8],
+    buf: &mut [F; 2],
+) {
+    assert!(domain_prefix.len() < 256);
+    assert!((18 + method.len() + curve_id.len() + domain_prefix.len()) < 256);
+
+    // Assume that the field size is 32 bytes and k is 256, where k is defined in
+    // <https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-10.html#name-security-considerations-3>.
+    const CHUNKLEN: usize = 64;
+    const_assert!(CHUNKLEN * 2 < 256);
+
+    // Input block size of BLAKE2b.
+    const R_IN_BYTES: usize = 128;
+
+    let personal = [0u8; 16];
+    let empty_hasher = blake2b_simd::Params::new()
+        .hash_length(CHUNKLEN)
+        .personal(&personal)
+        .to_state();
+
+    let b_0 = empty_hasher
+        .clone()
+        .update(&[0; R_IN_BYTES])
+        .update(message)
+        .update(&[0, (CHUNKLEN * 2) as u8, 0])
+        .update(domain_prefix.as_bytes())
+        .update(b"-")
+        .update(curve_id.as_bytes())
+        .update(b"_XMD:BLAKE2b_")
+        .update(method.as_bytes())
+        .update(b"_RO_")
+        .update(&[(18 + method.len() + curve_id.len() + domain_prefix.len()) as u8])
+        .finalize();
+
+    let b_1 = empty_hasher
+        .clone()
+        .update(b_0.as_array())
+        .update(&[1])
+        .update(domain_prefix.as_bytes())
+        .update(b"-")
+        .update(curve_id.as_bytes())
+        .update(b"_XMD:BLAKE2b_")
+        .update(method.as_bytes())
+        .update(b"_RO_")
+        .update(&[(18 + method.len() + curve_id.len() + domain_prefix.len()) as u8])
+        .finalize();
+
+    let b_2 = {
+        let mut empty_hasher = empty_hasher;
+        for (l, r) in b_0.as_array().iter().zip(b_1.as_array().iter()) {
+            empty_hasher.update(&[*l ^ *r]);
+        }
+        empty_hasher
+            .update(&[2])
+            .update(domain_prefix.as_bytes())
+            .update(b"-")
+            .update(curve_id.as_bytes())
+            .update(b"_XMD:BLAKE2b_")
+            .update(method.as_bytes())
+            .update(b"_RO_")
+            .update(&[(18 + method.len() + curve_id.len() + domain_prefix.len()) as u8])
+            .finalize()
+    };
+
+    for (big, buf) in [b_1, b_2].iter().zip(buf.iter_mut()) {
+        let mut little = [0u8; CHUNKLEN];
+        little.copy_from_slice(big.as_array());
+        little.reverse();
+        *buf = F::from_uniform_bytes(&little);
+    }
+}
+
+/// Implementation of https://www.ietf.org/id/draft-irtf-cfrg-hash-to-curve-16.html#name-shallue-van-de-woestijne-met
+#[allow(clippy::type_complexity)]
+pub(crate) fn svdw_map_to_curve<'a, C>(
+    curve_id: &'static str,
+    domain_prefix: &'a str,
+    z: C::Base,
+) -> Box<dyn Fn(&[u8]) -> C + 'a>
+where
+    C: CurveExt,
+    C::Base: FromUniformBytes<64>,
+{
+    let one = C::Base::ONE;
+    let three = one + one + one;
+    let four = three + one;
+    let a = C::a();
+    let b = C::b();
+    let tmp = three * z.square() + four * a;
+
+    // Precomputed constants:
+    // 1. c1 = g(Z)
+    let c1 = (z.square() + a) * z + b;
+    // 2. c2 = -Z / 2
+    let c2 = -z * C::Base::TWO_INV;
+    // 3. c3 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))    # sgn0(c3) MUST equal 0
+    let c3 = {
+        let c3 = (-c1 * tmp).sqrt().unwrap();
+        C::Base::conditional_select(&c3, &-c3, c3.is_odd())
+    };
+    // 4. c4 = -4 * g(Z) / (3 * Z^2 + 4 * A)
+    let c4 = -four * c1 * tmp.invert().unwrap();
+
+    Box::new(move |message| {
+        let mut us = [C::Base::ZERO; 2];
+        hash_to_field("SVDW", curve_id, domain_prefix, message, &mut us);
+
+        let [q0, q1] = us.map(|u| {
+            // 1. tv1 = u^2
+            let tv1 = u.square();
+            // 2. tv1 = tv1 * c1
+            let tv1 = tv1 * c1;
+            // 3. tv2 = 1 + tv1
+            let tv2 = one + tv1;
+            // 4. tv1 = 1 - tv1
+            let tv1 = one - tv1;
+            // 5. tv3 = tv1 * tv2
+            let tv3 = tv1 * tv2;
+            // 6. tv3 = inv0(tv3)
+            let tv3 = tv3.invert().unwrap_or(C::Base::ZERO);
+            // 7. tv4 = u * tv1
+            let tv4 = u * tv1;
+            // 8. tv4 = tv4 * tv3
+            let tv4 = tv4 * tv3;
+            // 9. tv4 = tv4 * c3
+            let tv4 = tv4 * c3;
+            // 10. x1 = c2 - tv4
+            let x1 = c2 - tv4;
+            // 11. gx1 = x1^2
+            let gx1 = x1.square();
+            // 12. gx1 = gx1 + A
+            let gx1 = gx1 + a;
+            // 13. gx1 = gx1 * x1
+            let gx1 = gx1 * x1;
+            // 14. gx1 = gx1 + B
+            let gx1 = gx1 + b;
+            // 15. e1 = is_square(gx1)
+            let e1 = gx1.sqrt().is_some();
+            // 16. x2 = c2 + tv4
+            let x2 = c2 + tv4;
+            // 17. gx2 = x2^2
+            let gx2 = x2.square();
+            // 18. gx2 = gx2 + A
+            let gx2 = gx2 + a;
+            // 19. gx2 = gx2 * x2
+            let gx2 = gx2 * x2;
+            // 20. gx2 = gx2 + B
+            let gx2 = gx2 + b;
+            // 21. e2 = is_square(gx2) AND NOT e1    # Avoid short-circuit logic ops
+            let e2 = gx2.sqrt().is_some() & (!e1);
+            // 22. x3 = tv2^2
+            let x3 = tv2.square();
+            // 23. x3 = x3 * tv3
+            let x3 = x3 * tv3;
+            // 24. x3 = x3^2
+            let x3 = x3.square();
+            // 25. x3 = x3 * c4
+            let x3 = x3 * c4;
+            // 26. x3 = x3 + Z
+            let x3 = x3 + z;
+            // 27. x = CMOV(x3, x1, e1)    # x = x1 if gx1 is square, else x = x3
+            let x = C::Base::conditional_select(&x3, &x1, e1);
+            // 28. x = CMOV(x, x2, e2)    # x = x2 if gx2 is square and gx1 is not
+            let x = C::Base::conditional_select(&x, &x2, e2);
+            // 29. gx = x^2
+            let gx = x.square();
+            // 30. gx = gx + A
+            let gx = gx + a;
+            // 31. gx = gx * x
+            let gx = gx * x;
+            // 32. gx = gx + B
+            let gx = gx + b;
+            // 33. y = sqrt(gx)
+            let y = gx.sqrt().unwrap();
+            // 34. e3 = sgn0(u) == sgn0(y)
+            let e3 = u.is_odd().ct_eq(&y.is_odd());
+            // 35. y = CMOV(-y, y, e3)    # Select correct sign of y
+            let y = C::Base::conditional_select(&-y, &y, e3);
+            // 36. return (x, y)
+            C::new_jacobian(x, y, one).unwrap()
+        });
+
+        let r = q0 + &q1;
+        debug_assert!(bool::from(r.is_on_curve()));
+        r
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "asm", feature(asm_const))]
-
 mod arithmetic;
 pub mod hash_to_curve;
 pub mod pairing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,15 @@
 #![cfg_attr(feature = "asm", feature(asm_const))]
 
 mod arithmetic;
+pub mod hash_to_curve;
+pub mod pairing;
+pub mod serde;
 
 pub mod bn256;
 pub mod grumpkin;
-pub mod pairing;
 pub mod pasta;
 pub mod secp256k1;
 pub mod secp256r1;
-pub mod serde;
 
 #[macro_use]
 mod derive;

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -64,6 +64,7 @@ new_curve_impl!(
     SECP_A,
     SECP_B,
     "secp256k1",
+    |_, _| unimplemented!(),
 );
 
 impl CurveAffineExt for Secp256k1Affine {

--- a/src/secp256r1/curve.rs
+++ b/src/secp256r1/curve.rs
@@ -75,6 +75,7 @@ new_curve_impl!(
     SECP_A,
     SECP_B,
     "secp256r1",
+    |_, _| unimplemented!(),
 );
 
 impl CurveAffineExt for Secp256r1Affine {

--- a/src/secp256r1/fp.rs
+++ b/src/secp256r1/fp.rs
@@ -187,7 +187,7 @@ impl ff::Field for Fp {
 
     /// Computes the square root of this element, if it exists.
     fn sqrt(&self) -> CtOption<Self> {
-        let tmp = self.pow(&[
+        let tmp = self.pow([
             0x0000000000000000,
             0x0000000040000000,
             0x4000000000000000,
@@ -200,7 +200,7 @@ impl ff::Field for Fp {
     /// Computes the multiplicative inverse of this element,
     /// failing if the element is zero.
     fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime(&[
+        let tmp = self.pow_vartime([
             0xfffffffffffffffd,
             0x00000000ffffffff,
             0x0000000000000000,

--- a/src/secp256r1/fq.rs
+++ b/src/secp256r1/fq.rs
@@ -177,7 +177,7 @@ impl ff::Field for Fq {
     /// Computes the multiplicative inverse of this element,
     /// failing if the element is zero.
     fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime(&[
+        let tmp = self.pow_vartime([
             0xf3b9cac2fc63254f,
             0xbce6faada7179e84,
             0xffffffffffffffff,
@@ -214,7 +214,7 @@ impl ff::Field for Fq {
             0x7fffffff8000000,
         ];
 
-        ff::helpers::sqrt_tonelli_shanks(self, &tm1d2)
+        ff::helpers::sqrt_tonelli_shanks(self, tm1d2)
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
@@ -344,18 +344,12 @@ mod test {
 
     #[test]
     fn test_delta() {
-        assert_eq!(
-            Fq::DELTA,
-            Fq::MULTIPLICATIVE_GENERATOR.pow(&[1u64 << Fq::S, 0, 0, 0])
-        );
+        assert_eq!(Fq::DELTA, Fq::MULTIPLICATIVE_GENERATOR.pow([1u64 << Fq::S]));
     }
 
     #[test]
     fn test_root_of_unity() {
-        assert_eq!(
-            Fq::ROOT_OF_UNITY.pow_vartime(&[1 << Fq::S, 0, 0, 0]),
-            Fq::one()
-        );
+        assert_eq!(Fq::ROOT_OF_UNITY.pow_vartime([1 << Fq::S]), Fq::one());
     }
 
     #[test]

--- a/src/tests/curve.rs
+++ b/src/tests/curve.rs
@@ -4,7 +4,8 @@ use crate::ff::Field;
 use crate::group::prime::PrimeCurveAffine;
 use crate::{group::GroupEncoding, serde::SerdeObject};
 use crate::{CurveAffine, CurveExt};
-use rand_core::OsRng;
+use rand_core::{OsRng, RngCore};
+use std::iter;
 
 #[cfg(feature = "derive_serde")]
 use serde::{Deserialize, Serialize};
@@ -312,5 +313,17 @@ fn multiplication<G: CurveExt>() {
         let s3 = s1 + s2;
         t1 = a * s3;
         assert_eq!(t0, t1);
+    }
+}
+
+pub fn hash_to_curve_test<G: CurveExt>() {
+    let hasher = G::hash_to_curve("test");
+    let mut rng = OsRng;
+    for _ in 0..1000 {
+        let message = iter::repeat_with(|| rng.next_u32().to_be_bytes())
+            .take(32)
+            .flatten()
+            .collect::<Vec<_>>();
+        assert!(bool::from(hasher(&message).is_on_curve()));
     }
 }

--- a/src/tests/field.rs
+++ b/src/tests/field.rs
@@ -48,7 +48,7 @@ pub fn random_field_tests<F: Field>(type_name: String) {
 }
 
 fn random_multiplication_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let _message = format!("multiplication {}", type_name);
+    let _message = format!("multiplication {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
@@ -74,7 +74,7 @@ fn random_multiplication_tests<F: Field, R: RngCore>(mut rng: R, type_name: Stri
 }
 
 fn random_addition_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let _message = format!("addition {}", type_name);
+    let _message = format!("addition {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
@@ -100,7 +100,7 @@ fn random_addition_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_subtraction_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let _message = format!("subtraction {}", type_name);
+    let _message = format!("subtraction {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
@@ -121,7 +121,7 @@ fn random_subtraction_tests<F: Field, R: RngCore>(mut rng: R, type_name: String)
 }
 
 fn random_negation_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let _message = format!("negation {}", type_name);
+    let _message = format!("negation {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
@@ -135,7 +135,7 @@ fn random_negation_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_doubling_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let _message = format!("doubling {}", type_name);
+    let _message = format!("doubling {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let mut a = F::random(&mut rng);
@@ -149,7 +149,7 @@ fn random_doubling_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_squaring_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let _message = format!("squaring {}", type_name);
+    let _message = format!("squaring {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let mut a = F::random(&mut rng);
@@ -165,7 +165,7 @@ fn random_squaring_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 fn random_inversion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
     assert!(bool::from(F::ZERO.invert().is_none()));
 
-    let _message = format!("inversion {}", type_name);
+    let _message = format!("inversion {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let mut a = F::random(&mut rng);
@@ -178,7 +178,7 @@ fn random_inversion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
 }
 
 fn random_expansion_tests<F: Field, R: RngCore>(mut rng: R, type_name: String) {
-    let _message = format!("expansion {}", type_name);
+    let _message = format!("expansion {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         // Compare (a + b)(c + d) and (a*c + b*c + a*d + b*d)
@@ -218,7 +218,7 @@ pub fn random_bits_tests<F: ff::PrimeFieldBits>(type_name: String) {
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
     ]);
-    let _message = format!("to_le_bits {}", type_name);
+    let _message = format!("to_le_bits {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
@@ -236,7 +236,7 @@ pub fn random_serialization_test<F: Field + SerdeObject>(type_name: String) {
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
     ]);
-    let _message = format!("serialization with SerdeObject {}", type_name);
+    let _message = format!("serialization with SerdeObject {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);
@@ -260,7 +260,7 @@ where
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
     ]);
-    let _message = format!("serialization with serde {}", type_name);
+    let _message = format!("serialization with serde {type_name}");
     let start = start_timer!(|| _message);
     for _ in 0..1000000 {
         let a = F::random(&mut rng);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,2 +1,17 @@
+use ff::PrimeField;
+use num_bigint::BigUint;
+use num_traits::Num;
+use std::borrow::Cow;
+
 pub mod curve;
 pub mod field;
+
+pub(crate) fn fe_from_str<F: PrimeField>(string: impl AsRef<str>) -> F {
+    let string = string.as_ref();
+    let oct = if let Some(hex) = string.strip_prefix("0x") {
+        Cow::Owned(BigUint::from_str_radix(hex, 16).unwrap().to_string())
+    } else {
+        Cow::Borrowed(string)
+    };
+    F::from_str_vartime(&oct).unwrap()
+}


### PR DESCRIPTION
This PR takes the `hash_to_field` from `pasta_curves` and implements the rest `CurveExt::hash_to_curve` for these curves:

- `bn256::G1` and `grumpkin::G1`

  With [Shallue-van de Woestijne method]. Originally I was exploring implementation of [Simplified SWU for AB == 0] for them, but after playing with the sage script to find their isogeny it turns out the degree is so high (59) which might be even slower than the SVDW method (I saw in gnark they are also using SVDW method for BN256).

  Although the spec doens't prepare test vectors for these 2 curves, I found in `gnark` they have the output of the same input from the spec with the same method for `bn254` [here](https://github.com/ConsenSys/gnark-crypto/blob/441dc0ffe639294b8d09e394f24ba7575577229c/ecc/bn254/hash_vectors_test.go#L29), so perhaps checking with that we can have more confidence on the implementation. [This PR](https://github.com/privacy-scaling-explorations/halo2curves/pull/50) aims for letting the CI to run the check for us, and the difference between `pasta_curves` and spec could be found in this [diff](https://github.com/privacy-scaling-explorations/halo2curves/commit/17b45df19ed468fef2bd5f5c5fde41c2d366c559), simply speaking the difference in `hash_to_field` are:
    1. Use `sha256` instead of `blake2b`
    2. Use `k = 128` instead of `k = 256` (which seems more accurate)
    3. Interpret the digest as big-endian integer and reduce it with modulus directly instead of using `from_u512`

  For the first point it seems fine, but for the other 2 I'm not sure if we should follow the implementation of `pasta_curves` or the spec..
- ~`secp256k1::Secp256k1`~

    ~With [Simplified SWU for AB == 0]. Parameters are taken from [3-isogeny map for secp256k1] and implementation is modified from https://github.com/zcash/pasta_curves.~
    It turns out we need to update the `new_curve_impl` to support `a != 0` curve to have isogeny of `secp256k1` to do the addition (we could copy paste the addition algorithm but it seems not looking good). So I'd keep this for future work.

And internally the hash function is using `blake2b` following `pasta_curves`, not sure if we need to make it generic but at least for IPA parameter generation I think it's fine to just use `blake2b`.

[Shallue-van de Woestijne method]: https://www.ietf.org/id/draft-irtf-cfrg-hash-to-curve-16.html#name-shallue-van-de-woestijne-me
[Simplified SWU for AB == 0]: https://www.ietf.org/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-swu-for-ab-0
[3-isogeny map for secp256k1]: https://www.ietf.org/id/draft-irtf-cfrg-hash-to-curve-16.html#name-3-isogeny-map-for-secp256k1