### PR TITLE
feat: Support Serialize/Deserialize for CompressedGroup under the derive_serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,14 @@ num-bigint = "0.4.3"
 num-traits = "0.2"
 paste = "1.0.11"
 serde = { version = "1.0", default-features = false, optional = true }
+serde_arrays = { version = "0.1.0", optional = true }
 
 [features]
 default = ["reexport", "bits"]
 asm = []
 prefetch = []
 print-trace = ["ark-std/print-trace"]
-derive_serde = ["serde/derive"]
+derive_serde = ["serde/derive", "serde_arrays"]
 reexport = []
 bits = ["ff/bits"]
 

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -159,8 +159,9 @@ macro_rules! new_curve_impl {
 
                 #[allow(non_upper_case_globals)]
                 const [< $name _COMPRESSED_SIZE >]: usize = if $flags_extra_byte {$base::size() + 1} else {$base::size()};
-                #[derive(Copy, Clone)]
-                pub struct [<$name Compressed >]([u8; [< $name _COMPRESSED_SIZE >]]);
+                #[derive(Copy, Clone, PartialEq, Eq)]
+                #[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
+                pub struct [<$name Compressed >](#[cfg_attr(feature = "derive_serde", serde(with = "serde_arrays"))] [u8; [< $name _COMPRESSED_SIZE >]]);
 
                 // Compressed
                 impl std::fmt::Debug for [< $name Compressed >] {


### PR DESCRIPTION
- Add optional `serde_arrays` dependency to support serialization of compressed group elements,
- Update `derive_serde` feature to incorporate new dependency.

This is useful for, e.g., [Nova](https://github.com/microsoft/Nova/blob/7193483628397328d779d36d6993e5a42ee9212a/src/traits/mod.rs#L54-L56) support.