### PR TITLE
Mask `ysign` as `bool`

### DIFF
--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -249,7 +249,7 @@ macro_rules! new_curve_impl {
                         let bytes = &bytes.0;
                         let mut tmp = *bytes;
                         let is_inf = Choice::from(tmp[[< $name _COMPRESSED_SIZE >] - 1] >> 7);
-                        let ysign = Choice::from(tmp[[< $name _COMPRESSED_SIZE >] - 1] >> 6);
+                        let ysign = Choice::from((tmp[[< $name _COMPRESSED_SIZE >] - 1] >> 6) & 1);
                         tmp[[< $name _COMPRESSED_SIZE >] - 1] &= 0b0011_1111;
                         let mut xbytes = [0u8; $base::size()];
                         xbytes.copy_from_slice(&tmp[ ..$base::size()]);

--- a/src/tests/curve.rs
+++ b/src/tests/curve.rs
@@ -23,6 +23,16 @@ pub fn curve_tests<G: CurveExt>() {
 }
 
 fn serdes<G: CurveExt>() {
+    assert!(bool::from(
+        G::from_bytes(&G::identity().to_bytes())
+            .unwrap()
+            .is_identity()
+    ));
+    assert!(bool::from(
+        G::AffineExt::from_bytes(&G::AffineExt::identity().to_bytes())
+            .unwrap()
+            .is_identity()
+    ));
     for _ in 0..100 {
         let projective_point = G::random(OsRng);
         let affine_point: G::AffineExt = projective_point.into();


### PR DESCRIPTION
This is a fixed in #44 by @chaosma but it's overwritten by #47 which forgets to pick it.

The check was passing because we are testing in release mode which doesn't have `debug-assertions` enabled, while `Choice::from(u8)` only uses `debug_assert` to check input is a bool.