### PR TITLE
fix: Alert if publisher doesn't have cargo-release installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ release:
 ifndef VERSION
 	$(error VERSION is not set. Run with `make VERSION=<version> release`)
 endif
+ifeq (, $(shell cargo-release --version))
+	$(error "Please, install cargo-release in order to be able to use this rule")
+endif
 	git pull
 	cargo update
 	git tag v$(VERSION) 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ release:
 ifndef VERSION
 	$(error VERSION is not set. Run with `make VERSION=<version> release`)
 endif
-ifeq (, $(shell cargo-release --version))
+ifeq (, $(shell cargo --list|grep release))
 	$(error "Please, install cargo-release in order to be able to use this rule")
 endif
 	git pull


### PR DESCRIPTION
Resolves: #61 (or at least prevents it to happen again)