### PR TITLE
chore: Bump to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["Privacy Scaling Explorations team"]
 license = "MIT/Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
This should release Secp cycle as well as some performance improvements.

This also unblocks https://github.com/microsoft/Nova/pull/199