### PR TITLE
Bring back curve algorithms for `a = 0`

### DIFF
--- a/benches/group.rs
+++ b/benches/group.rs
@@ -18,28 +18,28 @@ fn criterion_benchmark<G: CurveExt>(c: &mut Criterion) {
         let v = vec![G::generator(); N];
         let mut q = vec![G::AffineExt::identity(); N];
 
-        c.bench_function(&format!("{} check on curve", name), move |b| {
+        c.bench_function(&format!("{name} check on curve"), move |b| {
             b.iter(|| black_box(p1).is_on_curve())
         });
-        c.bench_function(&format!("{} check equality", name), move |b| {
+        c.bench_function(&format!("{name} check equality"), move |b| {
             b.iter(|| black_box(p1) == black_box(p1))
         });
-        c.bench_function(&format!("{} to affine", name), move |b| {
+        c.bench_function(&format!("{name} to affine"), move |b| {
             b.iter(|| G::AffineExt::from(black_box(p1)))
         });
-        c.bench_function(&format!("{} doubling", name), move |b| {
+        c.bench_function(&format!("{name} doubling"), move |b| {
             b.iter(|| black_box(p1).double())
         });
-        c.bench_function(&format!("{} addition", name), move |b| {
+        c.bench_function(&format!("{name} addition"), move |b| {
             b.iter(|| black_box(p1).add(&p2))
         });
-        c.bench_function(&format!("{} mixed addition", name), move |b| {
+        c.bench_function(&format!("{name} mixed addition"), move |b| {
             b.iter(|| black_box(p2).add(&p1_affine))
         });
-        c.bench_function(&format!("{} scalar multiplication", name), move |b| {
+        c.bench_function(&format!("{name} scalar multiplication"), move |b| {
             b.iter(|| black_box(p1) * black_box(s))
         });
-        c.bench_function(&format!("{} batch to affine n={}", name, N), move |b| {
+        c.bench_function(&format!("{name} batch to affine n={N}"), move |b| {
             b.iter(|| {
                 G::batch_normalize(black_box(&v), black_box(&mut q));
                 black_box(&q)[0]

--- a/benches/hash_to_curve.rs
+++ b/benches/hash_to_curve.rs
@@ -40,7 +40,7 @@ fn hash_to_curve<G: CurveExt>(c: &mut Criterion, name: &'static str) {
             .flatten()
             .collect::<Vec<_>>();
 
-        c.bench_function(&format!("Hash to {}", name), move |b| {
+        c.bench_function(&format!("Hash to {name}"), move |b| {
             b.iter(|| hasher(black_box(&message)))
         });
     }

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -135,7 +135,7 @@ impl Legendre for Fq2 {
             static ref LEGENDRE_EXP: Vec<u64> =
                 (num_bigint::BigUint::from_bytes_le((-<Fq as ff::Field>::ONE).to_repr().as_ref())/2usize).to_u64_digits();
         }
-        &*LEGENDRE_EXP
+        &LEGENDRE_EXP
     }
 
     /// Norm of Fq2 as extension field in i over Fq

--- a/src/legendre.rs
+++ b/src/legendre.rs
@@ -28,7 +28,7 @@ pub trait Legendre: Field {
 #[macro_export]
 macro_rules! prime_field_legendre {
     ($field:ident ) => {
-        impl crate::legendre::Legendre for $field {
+        impl $crate::legendre::Legendre for $field {
             type BasePrimeField = Self;
 
             #[inline]


### PR DESCRIPTION
This PR aims to mitigate the performance drop of curves with `a = 0` since #34. It also fixes some clippy warnings.

The benchmark of `group.rs` has the similar output (± 2%) as commit 21def8d900f088b325b61d6d8fe2777975960d28 that is right before #34.

Resolves #71.