### PR TITLE
Support bls12 381 temporarilly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ paste = "1.0.11"
 serde = { version = "1.0", default-features = false, optional = true }
 serde_arrays = { version = "0.1.0", optional = true }
 blake2b_simd = "1"
+bls12_381 = { git = "https://github.com/privacy-scaling-explorations/bls12_381", branch =  "feat/pub_fq", features = ["groups", "basefield"] }
 
 [features]
 default = ["reexport", "bits"]

--- a/src/bls12_381/mod.rs
+++ b/src/bls12_381/mod.rs
@@ -1,0 +1,65 @@
+use crate::arithmetic::mul_512;
+use crate::arithmetic::sbb;
+use crate::{
+    arithmetic::{CurveEndo, EndoParameters},
+    endo,
+};
+pub use bls12_381::{Fp, G1Projective, Scalar};
+use ff::PrimeField;
+use ff::WithSmallOrderMulGroup;
+use std::convert::TryInto;
+
+// Obtained from https://github.com/kilic/bls12-381/blob/master/glv.go and originally
+// generated using https://github.com/ConsenSys/gnark-crypto/blob/master/ecc/utils.go
+// See https://github.com/demining/Endomorphism-Secp256k1/blob/main/README.md
+// to have more details about the endomorphism.
+const ENDO_PARAMS_EP: EndoParameters = EndoParameters {
+    // round(b2/n)
+    gamma1: [0x63f6e522f6cfee30, 0x7c6becf1e01faadd, 0x01],
+    // round(-b1/n)
+    gamma2: [0x02, 0x0, 0x0, 0x0],
+    b1: [0x01, 0x0, 0x0, 0x0],
+    b2: [0x0000000100000000, 0xac45a4010001a402, 0x0, 0x0],
+};
+
+endo!(G1Projective, Fp, ENDO_PARAMS_EP);
+
+#[test]
+fn test_endo() {
+    use ff::Field;
+    use rand_core::OsRng;
+
+    for _ in 0..100000 {
+        let k = Fp::random(OsRng);
+        let (k1, k1_neg, k2, k2_neg) = Eq::decompose_scalar(&k);
+        if k1_neg & k2_neg {
+            assert_eq!(k, -Fp::from_u128(k1) + Fp::ZETA * Fp::from_u128(k2))
+        } else if k1_neg {
+            assert_eq!(k, -Fp::from_u128(k1) - Fp::ZETA * Fp::from_u128(k2))
+        } else if k2_neg {
+            assert_eq!(k, Fp::from_u128(k1) + Fp::ZETA * Fp::from_u128(k2))
+        } else {
+            assert_eq!(k, Fp::from_u128(k1) - Fp::ZETA * Fp::from_u128(k2))
+        }
+    }
+
+    for _ in 0..100000 {
+        let k = Fp::random(OsRng);
+        let (k1, k1_neg, k2, k2_neg) = Eq::decompose_scalar(&k);
+        if k1_neg & k2_neg {
+            assert_eq!(k, -Fp::from_u128(k1) + Fp::ZETA * Fp::from_u128(k2))
+        } else if k1_neg {
+            assert_eq!(k, -Fp::from_u128(k1) - Fp::ZETA * Fp::from_u128(k2))
+        } else if k2_neg {
+            assert_eq!(k, Fp::from_u128(k1) + Fp::ZETA * Fp::from_u128(k2))
+        } else {
+            assert_eq!(k, Fp::from_u128(k1) - Fp::ZETA * Fp::from_u128(k2))
+        }
+    }
+}
+
+#[test]
+fn test_quadratic_residue() {
+    crate::tests::field::random_quadratic_residue_test::<Fp>();
+    crate::tests::field::random_quadratic_residue_test::<Fq>();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod hash_to_curve;
 pub mod legendre;
 pub mod serde;
 
+pub mod bls12_381;
 pub mod bn256;
 pub mod grumpkin;
 pub mod pasta;


### PR DESCRIPTION
This is an attempt to temporarily providing support for Bls12-381 in halo2curves.

This will require first to complete: https://github.com/privacy-scaling-explorations/bls12_381/pull/4 so that `CurveExt` is implemented for `G1Projective` so that the trait requirements for `CruveEndo` are met.