### PR TITLE
refactor: (De)Serialization of points using `GroupEncoding`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ criterion = { version = "0.3", features = ["html_reports"] }
 rand_xorshift = "0.3"
 ark-std = { version = "0.3" }
 bincode = "1.3.3"
+serde_json = "1.0.105"
 
 [dependencies]
 subtle = "2.4"
@@ -30,6 +31,7 @@ num-traits = "0.2"
 paste = "1.0.11"
 serde = { version = "1.0", default-features = false, optional = true }
 serde_arrays = { version = "0.1.0", optional = true }
+hex = { version = "0.4", optional = true, default-features = false, features = ["alloc", "serde"] }
 blake2b_simd = "1"
 
 [features]
@@ -37,7 +39,7 @@ default = ["reexport", "bits"]
 asm = []
 bits = ["ff/bits"]
 bn256-table = []
-derive_serde = ["serde/derive", "serde_arrays"]
+derive_serde = ["serde/derive", "serde_arrays", "hex"]
 prefetch = []
 print-trace = ["ark-std/print-trace"]
 reexport = []

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -289,8 +289,72 @@ macro_rules! new_curve_impl {
 
         }
 
+        /// A macro to help define point serialization using the [`group::GroupEncoding`] trait
+        /// This assumes both point types ($name, $nameaffine) implement [`group::GroupEncoding`].
+        #[cfg(feature = "derive_serde")]
+        macro_rules! serialize_deserialize_to_from_bytes {
+            () => {
+                impl ::serde::Serialize for $name {
+                    fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                        let bytes = &self.to_bytes();
+                        if serializer.is_human_readable() {
+                            ::hex::serde::serialize(&bytes.0, serializer)
+                        } else {
+                            ::serde_arrays::serialize(&bytes.0, serializer)
+                        }
+                    }
+                }
+
+                paste::paste! {
+                    use ::serde::de::Error as _;
+                    impl<'de> ::serde::Deserialize<'de> for $name {
+                        fn deserialize<D: ::serde::Deserializer<'de>>(
+                            deserializer: D,
+                        ) -> Result<Self, D::Error> {
+                            let bytes = if deserializer.is_human_readable() {
+                                ::hex::serde::deserialize(deserializer)?
+                            } else {
+                                ::serde_arrays::deserialize::<_, u8, [< $name _COMPRESSED_SIZE >]>(deserializer)?
+                            };
+                            Option::from(Self::from_bytes(&[< $name Compressed >](bytes))).ok_or_else(|| {
+                                D::Error::custom("deserialized bytes don't encode a valid field element")
+                            })
+                        }
+                    }
+                }
+
+                impl ::serde::Serialize for $name_affine {
+                    fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                        let bytes = &self.to_bytes();
+                        if serializer.is_human_readable() {
+                            ::hex::serde::serialize(&bytes.0, serializer)
+                        } else {
+                            ::serde_arrays::serialize(&bytes.0, serializer)
+                        }
+                    }
+                }
+
+                paste::paste! {
+                    use ::serde::de::Error as _;
+                    impl<'de> ::serde::Deserialize<'de> for $name_affine {
+                        fn deserialize<D: ::serde::Deserializer<'de>>(
+                            deserializer: D,
+                        ) -> Result<Self, D::Error> {
+                            let bytes = if deserializer.is_human_readable() {
+                                ::hex::serde::deserialize(deserializer)?
+                            } else {
+                                ::serde_arrays::deserialize::<_, u8, [< $name _COMPRESSED_SIZE >]>(deserializer)?
+                            };
+                            Option::from(Self::from_bytes(&[< $name Compressed >](bytes))).ok_or_else(|| {
+                                D::Error::custom("deserialized bytes don't encode a valid field element")
+                            })
+                        }
+                    }
+                }
+            };
+        }
+
         #[derive(Copy, Clone, Debug)]
-        #[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
         $($privacy)* struct $name {
             pub x: $base,
             pub y: $base,
@@ -298,13 +362,13 @@ macro_rules! new_curve_impl {
         }
 
         #[derive(Copy, Clone, PartialEq)]
-        #[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
         $($privacy)* struct $name_affine {
             pub x: $base,
             pub y: $base,
         }
 
-
+        #[cfg(feature = "derive_serde")]
+        serialize_deserialize_to_from_bytes!();
 
         impl_compressed!();
         impl_uncompressed!();


### PR DESCRIPTION
## Context

In https://github.com/privacy-scaling-explorations/halo2curves/pull/30 and in https://github.com/privacy-scaling-explorations/halo2curves/pull/39 this repo implemented the `SerdeObject` that allows straight-line serialization and de-serialization of the internal point representation. This practice makes a lot of sense when (de)serialization is used to do local caching in zk-algorithms, and some sense when performing additions to e.g. a transcript.

However, it isn't compatible with classical point (de)serialization which more traditionally uses the compressed point representation, which is helpfully defined here as the implementation for the `zkcrypto/group::GroupEncoding` trait for both projective and affine point representations.

Precisely because the `SerdeObject` trait allows an alternate route to get the raw representation of point objects (and, IIUC, downstream repos use *these* code paths?), the default implementation of the `Serialize/Deserialize` traits could hence aim at compatibility and use the traditional compressed point representation for serde, which is what this PR suggests. 

In a nutshell, the `SerdeObject` code paths provide raw representation bytes, the `Serde` code paths provide the classical compressed point reresentations.

Because the implementation is limited to one single point of indirection (the serde annotation on `$name`, `$name_affine` becomes one macro call), we can also envision more optionality by e.g. opening a feature (e.g. "compressed_serde") allowing the user to pick and choose what serde would give them. 

## In detail
- Updated curve point (de)serialization logic from the internal representation to the representation offered by the implementation of the `GroupEncoding` trait.