### PR TITLE
Re-export also mod `pairing` and remove flag `reexport` to alwasy re-export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ blake2b_simd = "1"
 maybe-rayon = { version = "0.1.0", default-features = false }
 
 [features]
-default = ["reexport", "bits", "multicore"]
+default = ["bits", "multicore"]
 multicore = ["maybe-rayon/threads"]
 asm = []
 bits = ["ff/bits"]
@@ -44,7 +44,6 @@ bn256-table = []
 derive_serde = ["serde/derive", "serde_arrays", "hex"]
 prefetch = []
 print-trace = ["ark-std/print-trace"]
-reexport = []
 
 [profile.bench]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,17 +16,12 @@ pub mod secq256k1;
 
 #[macro_use]
 mod derive;
-pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
-// Re-export ff and group to simplify down stream dependencies
-#[cfg(feature = "reexport")]
+// Re-export to simplify down stream dependencies
 pub use ff;
-#[cfg(not(feature = "reexport"))]
-use ff;
-#[cfg(feature = "reexport")]
 pub use group;
-#[cfg(not(feature = "reexport"))]
-use group;
+pub use pairing;
+pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
 #[cfg(test)]
 pub mod tests;


### PR DESCRIPTION
Since https://github.com/privacy-scaling-explorations/halo2curves/pull/69 the mod `pairing` is no longer accessible by `halo2curves::pairing`, this PR aims to fix this to make downstream easier to maintain the dependency.