### PR TITLE
fix regression in #93 reexport field benches aren't run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ harness = false
 [[bench]]
 name = "bn256_field"
 harness = false
-required-features = ["reexport"]
 
 [[bench]]
 name = "group"


### PR DESCRIPTION
Following #93, field benches should not require reexport or they aren't run.