### PR TITLE
Fix nits in `bn256`.

### DIFF
--- a/src/bn256/fq12.rs
+++ b/src/bn256/fq12.rs
@@ -6,6 +6,11 @@ use core::ops::{Add, Mul, Neg, Sub};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+/// -GAMMA is a quadratic non-residue in Fp6. Fp12 = Fp6[X]/(X^2 + GAMMA)
+/// We introduce the variable w such that w^2 = -GAMMA
+// GAMMA = - v
+
+/// An element of Fq12, represented by c0 + c1 * w.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct Fq12 {
     pub c0: Fq6,

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -199,11 +199,12 @@ impl Fq2 {
     }
 
     pub fn mul_assign(&mut self, other: &Self) {
-        let mut t1 = self.c0 * other.c0;
         let mut t0 = self.c0 + self.c1;
+        let mut t1 = self.c0 * other.c0;
         let t2 = self.c1 * other.c1;
-        self.c1 = other.c0 + other.c1;
+
         self.c0 = t1 - t2;
+        self.c1 = other.c0 + other.c1;
         t1 += t2;
         t0 *= self.c1;
         self.c1 = t0 - t1;

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -10,7 +10,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "derive_serde")]
 use serde::{Deserialize, Serialize};
 
-/// An element of Fq2, represented by c0 + c1 * u.
+/// An element of Fq2, represented by c0 + c1 * u; where u^2 = -1.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
 pub struct Fq2 {

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -271,12 +271,14 @@ impl Fq2 {
     }
 
     pub fn frobenius_map(&mut self, power: usize) {
-        self.c1 *= &FROBENIUS_COEFF_FQ2_C1[power % 2];
+        if power % 2 != 0 {
+            self.conjugate()
+        }
     }
 
     /// Multiply this element by quadratic nonresidue 9 + u.
     pub fn mul_by_nonresidue(&mut self) {
-        // (xi+y)(i+9) = (9x+y)i+(9y-x)
+        // (xu+y)(u+9) = (9x+y)u+(9y-x)
         let t0 = self.c0;
         let t1 = self.c1;
 
@@ -290,29 +292,7 @@ impl Fq2 {
         // (9*y - x)
         self.c0 -= &t1;
 
-        // (9*x)i
-        self.c1 += &t1;
-        // (9*x + y)
-        self.c1 += &t0;
-    }
-
-    // Multiply this element by ξ where ξ=i+9
-    pub fn mul_by_xi(&mut self) {
-        // (xi+y)(i+9) = (9x+y)i+(9y-x)
-        let t0 = self.c0;
-        let t1 = self.c1;
-
-        // 8*x*i + 8*y
-        self.double_assign();
-        self.double_assign();
-        self.double_assign();
-
-        // 9*y
-        self.c0 += &t0;
-        // (9*y - x)
-        self.c0 -= &t1;
-
-        // (9*x)i
+        // (9*x)u
         self.c1 += &t1;
         // (9*x + y)
         self.c1 += &t0;
@@ -566,24 +546,6 @@ impl WithSmallOrderMulGroup<3> for Fq2 {
         c1: Fq::zero(),
     };
 }
-
-pub const FROBENIUS_COEFF_FQ2_C1: [Fq; 2] = [
-    // Fq(-1)**(((q^0) - 1) / 2)
-    // it's 1 in Montgommery form
-    Fq([
-        0xd35d438dc58f0d9d,
-        0x0a78eb28f5c70b3d,
-        0x666ea36f7879462c,
-        0x0e0a77c19a07df2f,
-    ]),
-    // Fq(-1)**(((q^1) - 1) / 2)
-    Fq([
-        0x68c3488912edefaa,
-        0x8d087f6872aabf4f,
-        0x51e1a24709081231,
-        0x2259d6b14729c0fa,
-    ]),
-];
 
 #[cfg(test)]
 use rand::SeedableRng;

--- a/src/bn256/fq6.rs
+++ b/src/bn256/fq6.rs
@@ -5,6 +5,11 @@ use core::ops::{Add, Mul, Neg, Sub};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+/// -BETA is a cubic non-residue in Fp2. Fp6 = Fp2[X]/(X^3 + BETA)
+/// We introduce the variable v such that v^3 = -BETA
+// BETA = - (u + 9)
+
+/// An element of Fq6, represented by c0 + c1 * v + c2 * v^2.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct Fq6 {
     pub c0: Fq2,

--- a/src/bn256/fq6.rs
+++ b/src/bn256/fq6.rs
@@ -190,7 +190,6 @@ impl Fq6 {
         // new c1 = (c^2).mul_by_xi + 2ab
         self.c1 = s4;
         self.c1.mul_by_nonresidue();
-        // self.c1.mul_by_xi();
         self.c1 += &s1;
 
         // new c2 = 2ab + (a - b + c)^2 + 2bc - a^2 - c^2 = b^2 + 2ac
@@ -267,15 +266,6 @@ impl Fq6 {
         swap(&mut self.c0, &mut self.c2);
         // c0, c1, c2 -> c2, c0, c1
         self.c0.mul_by_nonresidue();
-    }
-
-    /// Multiply by cubic nonresidue v.
-    pub fn mul_by_v(&mut self) {
-        use std::mem::swap;
-        swap(&mut self.c0, &mut self.c1);
-        swap(&mut self.c0, &mut self.c2);
-
-        self.c0.mul_by_xi();
     }
 
     pub fn mul_by_1(&mut self, c1: &Fq2) {

--- a/src/bn256/fq6.rs
+++ b/src/bn256/fq6.rs
@@ -508,7 +508,7 @@ pub const FROBENIUS_COEFF_FQ6_C1: [Fq2; 6] = [
 ];
 
 pub const FROBENIUS_COEFF_FQ6_C2: [Fq2; 6] = [
-    // Fq2(u + 1)**(((2q^0) - 2) / 3)
+    // Fq2(u + 9)**(((2q^0) - 2) / 3)
     Fq2 {
         c0: Fq([
             0xd35d438dc58f0d9d,
@@ -518,7 +518,7 @@ pub const FROBENIUS_COEFF_FQ6_C2: [Fq2; 6] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((2q^1) - 2) / 3)
+    // Fq2(u + 9)**(((2q^1) - 2) / 3)
     Fq2 {
         c0: Fq([
             0x7361d77f843abe92,
@@ -533,7 +533,7 @@ pub const FROBENIUS_COEFF_FQ6_C2: [Fq2; 6] = [
             0x24830a9d3171f0fd,
         ]),
     },
-    // Fq2(u + 1)**(((2q^2) - 2) / 3)
+    // Fq2(u + 9)**(((2q^2) - 2) / 3)
     Fq2 {
         c0: Fq([
             0x71930c11d782e155,
@@ -543,7 +543,7 @@ pub const FROBENIUS_COEFF_FQ6_C2: [Fq2; 6] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((2q^3) - 2) / 3)
+    // Fq2(u + 9)**(((2q^3) - 2) / 3)
     Fq2 {
         c0: Fq([
             0x448a93a57b6762df,
@@ -558,7 +558,7 @@ pub const FROBENIUS_COEFF_FQ6_C2: [Fq2; 6] = [
             0x170c812b84dda0b2,
         ]),
     },
-    // Fq2(u + 1)**(((2q^4) - 2) / 3)
+    // Fq2(u + 9)**(((2q^4) - 2) / 3)
     Fq2 {
         c0: Fq([
             0x3350c88e13e80b9c,
@@ -568,7 +568,7 @@ pub const FROBENIUS_COEFF_FQ6_C2: [Fq2; 6] = [
         ]),
         c1: Fq([0x0, 0x0, 0x0, 0x0]),
     },
-    // Fq2(u + 1)**(((2q^5) - 2) / 3)
+    // Fq2(u + 9)**(((2q^5) - 2) / 3)
     Fq2 {
         c0: Fq([
             0x843420f1d8dadbd6,


### PR DESCRIPTION
Fixes #91 and #90.

This PR removes some unused functions and corrects some comments regarding its constants.