### PR TITLE
[fix/optimization] `mul_by_3b` special case should be `CURVE_ID == "bn256_g1"`

### DIFF
--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -393,7 +393,7 @@ macro_rules! new_curve_impl {
             }
 
             fn mul_by_3b(input: &$base) -> $base {
-                if $name::CURVE_ID == "bn256"{
+                if $name::CURVE_ID == "bn256_g1"{
                     input.double().double().double() + input
                 } else {
                     input * $name::curve_constant_3b()


### PR DESCRIPTION
It seems this special case optimization was not being triggered because the `CURVE_ID` didn't match.