### PR TITLE
Fix asm version of `from_512`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ rand_xorshift = "0.3"
 ark-std = { version = "0.3" }
 bincode = "1.3.3"
 serde_json = "1.0.105"
+hex = "0.4"
+rand_chacha = "0.3.1"
 
 [dependencies]
 subtle = "2.4"

--- a/src/bn256/mod.rs
+++ b/src/bn256/mod.rs
@@ -16,3 +16,43 @@ pub use fq12::*;
 pub use fq2::*;
 pub use fq6::*;
 pub use fr::*;
+
+#[cfg(test)]
+mod test {
+    use pasta_curves::arithmetic::CurveExt;
+    use group::GroupEncoding;
+    use rand_core::{SeedableRng, RngCore};
+    use super::G1 as Bn256Point;
+
+    #[test]
+    fn test_hash_to_curve_print(){
+        // the goal of this test is to generate test vectors to ensure that the ASM implementation matches the
+        // vanilla implementation
+        let num_vecs = 10;
+        let expected_results = [
+            "e0c5a6834e0329b4f8bdc91144b3e687ac9d810a8e899415267db9cfbf61e91e",
+            "7052a20bee99cbe054fdd8b2e336db3ed3e9a265229e44ab8197c5eabdef2b0b",
+            "2f058acc133957074ac79e9b9b1867a0cf3d13df7aa7de7f48e9a6be7d96aa6d",
+            "b2ff44a25693b811f35e33feb3e99ad9ba0d06425a3ffd5e79cef63d20143314",
+            "ab2f6d71d2fde51546d8a5782aa9f707e585b84644470f0c876784dbebd30c55",
+            "6a4e0e30f37a8d1b92b8cf08df3735a36b4937ee455a9dc5f9283a13530db144",
+            "f1c69be8c5f5f9e28b0e9f76ab77651a7dcaaae371fbba66450cbcee0ed5b16b",
+            "e86267c2e3355d7a6f664a0ea71374406337d452a3f9a294a0594df53c08df21",
+            "03cf55ca983ecd8a2e2baae18d979d97d688a978d829701c66a14d7c4da58e62",
+            "5302c2cfe3c909e9378d08c951bb33d0813818a1baf734379aac8aaa47f38f0d"
+        ];
+
+        let mut seeded_rng = rand_chacha::ChaChaRng::seed_from_u64(0u64);
+        let uniform_bytes = std::iter::from_fn(|| {
+            let mut bytes = [0u8; 32];
+            seeded_rng.fill_bytes(&mut bytes);
+            Some(bytes)
+        }).take(num_vecs).collect::<Vec<_>>();
+        let hash = Bn256Point::hash_to_curve("from_uniform_bytes");
+        for i in 0..num_vecs {
+            let p = hash(&uniform_bytes[i]);
+            let expected_result = hex::decode(expected_results[i]).unwrap();
+            assert_eq!(p.to_bytes().as_ref(), &expected_result[..], "hash_to_curve_print failed, expected: {}, got: {}", expected_results[i], hex::encode(p.to_bytes().as_ref()));
+        }
+    }
+}

--- a/src/bn256/mod.rs
+++ b/src/bn256/mod.rs
@@ -19,13 +19,13 @@ pub use fr::*;
 
 #[cfg(test)]
 mod test {
-    use pasta_curves::arithmetic::CurveExt;
-    use group::GroupEncoding;
-    use rand_core::{SeedableRng, RngCore};
     use super::G1 as Bn256Point;
+    use group::GroupEncoding;
+    use pasta_curves::arithmetic::CurveExt;
+    use rand_core::{RngCore, SeedableRng};
 
     #[test]
-    fn test_hash_to_curve_print(){
+    fn test_hash_to_curve_print() {
         // the goal of this test is to generate test vectors to ensure that the ASM implementation matches the
         // vanilla implementation
         let num_vecs = 10;
@@ -39,7 +39,7 @@ mod test {
             "f1c69be8c5f5f9e28b0e9f76ab77651a7dcaaae371fbba66450cbcee0ed5b16b",
             "e86267c2e3355d7a6f664a0ea71374406337d452a3f9a294a0594df53c08df21",
             "03cf55ca983ecd8a2e2baae18d979d97d688a978d829701c66a14d7c4da58e62",
-            "5302c2cfe3c909e9378d08c951bb33d0813818a1baf734379aac8aaa47f38f0d"
+            "5302c2cfe3c909e9378d08c951bb33d0813818a1baf734379aac8aaa47f38f0d",
         ];
 
         let mut seeded_rng = rand_chacha::ChaChaRng::seed_from_u64(0u64);
@@ -47,12 +47,20 @@ mod test {
             let mut bytes = [0u8; 32];
             seeded_rng.fill_bytes(&mut bytes);
             Some(bytes)
-        }).take(num_vecs).collect::<Vec<_>>();
+        })
+        .take(num_vecs)
+        .collect::<Vec<_>>();
         let hash = Bn256Point::hash_to_curve("from_uniform_bytes");
         for i in 0..num_vecs {
             let p = hash(&uniform_bytes[i]);
             let expected_result = hex::decode(expected_results[i]).unwrap();
-            assert_eq!(p.to_bytes().as_ref(), &expected_result[..], "hash_to_curve_print failed, expected: {}, got: {}", expected_results[i], hex::encode(p.to_bytes().as_ref()));
+            assert_eq!(
+                p.to_bytes().as_ref(),
+                &expected_result[..],
+                "hash_to_curve_print failed, expected: {}, got: {}",
+                expected_results[i],
+                hex::encode(p.to_bytes().as_ref())
+            );
         }
     }
 }

--- a/src/bn256/mod.rs
+++ b/src/bn256/mod.rs
@@ -25,10 +25,12 @@ mod test {
     use rand_core::{RngCore, SeedableRng};
 
     #[test]
-    fn test_hash_to_curve_print() {
-        // the goal of this test is to generate test vectors to ensure that the ASM implementation matches the
-        // vanilla implementation
+    fn test_consistent_hash_to_curve() {
+        // The goal of this test is to generate test vectors to ensure that the ASM implementation
+        // matches the rust implementation.
         let num_vecs = 10;
+
+        // Test vectors generated with rust implementation.
         let expected_results = [
             "e0c5a6834e0329b4f8bdc91144b3e687ac9d810a8e899415267db9cfbf61e91e",
             "7052a20bee99cbe054fdd8b2e336db3ed3e9a265229e44ab8197c5eabdef2b0b",

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -63,6 +63,74 @@ macro_rules! field_common {
                 $crate::ff_ext::jacobi::jacobi::<5>(&self.0, &$modulus.0)
             }
 
+            pub const fn montgomery_form(val: [u64; 4], r: $field) -> $field {
+                // Converts a 4 64-bit limb value into its congruent field representation.
+                // If `val` representes a 256 bit value then `r` should be R^2,
+                // if `val` represents the 256 MSB of a 512 bit value, then `r` should be R^3.
+
+                let (r0, carry) = mac(0, val[0], r.0[0], 0);
+                let (r1, carry) = mac(0, val[0], r.0[1], carry);
+                let (r2, carry) = mac(0, val[0], r.0[2], carry);
+                let (r3, r4) = mac(0, val[0], r.0[3], carry);
+
+                let (r1, carry) = mac(r1, val[1], r.0[0], 0);
+                let (r2, carry) = mac(r2, val[1], r.0[1], carry);
+                let (r3, carry) = mac(r3, val[1], r.0[2], carry);
+                let (r4, r5) = mac(r4, val[1], r.0[3], carry);
+
+                let (r2, carry) = mac(r2, val[2], r.0[0], 0);
+                let (r3, carry) = mac(r3, val[2], r.0[1], carry);
+                let (r4, carry) = mac(r4, val[2], r.0[2], carry);
+                let (r5, r6) = mac(r5, val[2], r.0[3], carry);
+
+                let (r3, carry) = mac(r3, val[3], r.0[0], 0);
+                let (r4, carry) = mac(r4, val[3], r.0[1], carry);
+                let (r5, carry) = mac(r5, val[3], r.0[2], carry);
+                let (r6, r7) = mac(r6, val[3], r.0[3], carry);
+
+                // Montgomery reduction
+                let k = r0.wrapping_mul($inv);
+                let (_, carry) = mac(r0, k, $modulus.0[0], 0);
+                let (r1, carry) = mac(r1, k, $modulus.0[1], carry);
+                let (r2, carry) = mac(r2, k, $modulus.0[2], carry);
+                let (r3, carry) = mac(r3, k, $modulus.0[3], carry);
+                let (r4, carry2) = adc(r4, 0, carry);
+
+                let k = r1.wrapping_mul($inv);
+                let (_, carry) = mac(r1, k, $modulus.0[0], 0);
+                let (r2, carry) = mac(r2, k, $modulus.0[1], carry);
+                let (r3, carry) = mac(r3, k, $modulus.0[2], carry);
+                let (r4, carry) = mac(r4, k, $modulus.0[3], carry);
+                let (r5, carry2) = adc(r5, carry2, carry);
+
+                let k = r2.wrapping_mul($inv);
+                let (_, carry) = mac(r2, k, $modulus.0[0], 0);
+                let (r3, carry) = mac(r3, k, $modulus.0[1], carry);
+                let (r4, carry) = mac(r4, k, $modulus.0[2], carry);
+                let (r5, carry) = mac(r5, k, $modulus.0[3], carry);
+                let (r6, carry2) = adc(r6, carry2, carry);
+
+                let k = r3.wrapping_mul($inv);
+                let (_, carry) = mac(r3, k, $modulus.0[0], 0);
+                let (r4, carry) = mac(r4, k, $modulus.0[1], carry);
+                let (r5, carry) = mac(r5, k, $modulus.0[2], carry);
+                let (r6, carry) = mac(r6, k, $modulus.0[3], carry);
+                let (r7, carry2) = adc(r7, carry2, carry);
+
+                // Result may be within MODULUS of the correct value
+                let (d0, borrow) = sbb(r4, $modulus.0[0], 0);
+                let (d1, borrow) = sbb(r5, $modulus.0[1], borrow);
+                let (d2, borrow) = sbb(r6, $modulus.0[2], borrow);
+                let (d3, borrow) = sbb(r7, $modulus.0[3], borrow);
+                let (_, borrow) = sbb(carry2, 0, borrow);
+                let (d0, carry) = adc(d0, $modulus.0[0] & borrow, 0);
+                let (d1, carry) = adc(d1, $modulus.0[1] & borrow, carry);
+                let (d2, carry) = adc(d2, $modulus.0[2] & borrow, carry);
+                let (d3, _) = adc(d3, $modulus.0[3] & borrow, carry);
+
+                $field([d0, d1, d2, d3])
+            }
+
             fn from_u512(limbs: [u64; 8]) -> $field {
                 // We reduce an arbitrary 512-bit number by decomposing it into two 256-bit digits
                 // with the higher bits multiplied by 2^256. Thus, we perform two reductions
@@ -77,10 +145,18 @@ macro_rules! field_common {
                 // that (2^256 - 1)*c is an acceptable product for the reduction. Therefore, the
                 // reduction always works so long as `c` is in the field; in this case it is either the
                 // constant `R2` or `R3`.
-                let d0 = $field([limbs[0], limbs[1], limbs[2], limbs[3]]);
-                let d1 = $field([limbs[4], limbs[5], limbs[6], limbs[7]]);
-                // Convert to Montgomery form
-                d0 * $r2 + d1 * $r3
+
+                let lower_256 = [limbs[0], limbs[1], limbs[2], limbs[3]];
+                let upper_256 = [limbs[4], limbs[5], limbs[6], limbs[7]];
+
+                #[cfg(feature = "asm")]
+                {
+                    Self::montgomery_form(lower_256, $r2) + Self::montgomery_form(upper_256, $r3)
+                }
+                #[cfg(not(feature = "asm"))]
+                {
+                    $field(lower_256) * $r2 + $field(upper_256) * $r3
+                }
             }
 
             /// Converts from an integer represented in little endian
@@ -88,67 +164,7 @@ macro_rules! field_common {
             pub const fn from_raw(val: [u64; 4]) -> Self {
                 #[cfg(feature = "asm")]
                 {
-                    let (r0, carry) = mac(0, val[0], $r2.0[0], 0);
-                    let (r1, carry) = mac(0, val[0], $r2.0[1], carry);
-                    let (r2, carry) = mac(0, val[0], $r2.0[2], carry);
-                    let (r3, r4) = mac(0, val[0], $r2.0[3], carry);
-
-                    let (r1, carry) = mac(r1, val[1], $r2.0[0], 0);
-                    let (r2, carry) = mac(r2, val[1], $r2.0[1], carry);
-                    let (r3, carry) = mac(r3, val[1], $r2.0[2], carry);
-                    let (r4, r5) = mac(r4, val[1], $r2.0[3], carry);
-
-                    let (r2, carry) = mac(r2, val[2], $r2.0[0], 0);
-                    let (r3, carry) = mac(r3, val[2], $r2.0[1], carry);
-                    let (r4, carry) = mac(r4, val[2], $r2.0[2], carry);
-                    let (r5, r6) = mac(r5, val[2], $r2.0[3], carry);
-
-                    let (r3, carry) = mac(r3, val[3], $r2.0[0], 0);
-                    let (r4, carry) = mac(r4, val[3], $r2.0[1], carry);
-                    let (r5, carry) = mac(r5, val[3], $r2.0[2], carry);
-                    let (r6, r7) = mac(r6, val[3], $r2.0[3], carry);
-
-                    // Montgomery reduction
-                    let k = r0.wrapping_mul($inv);
-                    let (_, carry) = mac(r0, k, $modulus.0[0], 0);
-                    let (r1, carry) = mac(r1, k, $modulus.0[1], carry);
-                    let (r2, carry) = mac(r2, k, $modulus.0[2], carry);
-                    let (r3, carry) = mac(r3, k, $modulus.0[3], carry);
-                    let (r4, carry2) = adc(r4, 0, carry);
-
-                    let k = r1.wrapping_mul($inv);
-                    let (_, carry) = mac(r1, k, $modulus.0[0], 0);
-                    let (r2, carry) = mac(r2, k, $modulus.0[1], carry);
-                    let (r3, carry) = mac(r3, k, $modulus.0[2], carry);
-                    let (r4, carry) = mac(r4, k, $modulus.0[3], carry);
-                    let (r5, carry2) = adc(r5, carry2, carry);
-
-                    let k = r2.wrapping_mul($inv);
-                    let (_, carry) = mac(r2, k, $modulus.0[0], 0);
-                    let (r3, carry) = mac(r3, k, $modulus.0[1], carry);
-                    let (r4, carry) = mac(r4, k, $modulus.0[2], carry);
-                    let (r5, carry) = mac(r5, k, $modulus.0[3], carry);
-                    let (r6, carry2) = adc(r6, carry2, carry);
-
-                    let k = r3.wrapping_mul($inv);
-                    let (_, carry) = mac(r3, k, $modulus.0[0], 0);
-                    let (r4, carry) = mac(r4, k, $modulus.0[1], carry);
-                    let (r5, carry) = mac(r5, k, $modulus.0[2], carry);
-                    let (r6, carry) = mac(r6, k, $modulus.0[3], carry);
-                    let (r7, carry2) = adc(r7, carry2, carry);
-
-                    // Result may be within MODULUS of the correct value
-                    let (d0, borrow) = sbb(r4, $modulus.0[0], 0);
-                    let (d1, borrow) = sbb(r5, $modulus.0[1], borrow);
-                    let (d2, borrow) = sbb(r6, $modulus.0[2], borrow);
-                    let (d3, borrow) = sbb(r7, $modulus.0[3], borrow);
-                    let (_, borrow) = sbb(carry2, 0, borrow);
-                    let (d0, carry) = adc(d0, $modulus.0[0] & borrow, 0);
-                    let (d1, carry) = adc(d1, $modulus.0[1] & borrow, carry);
-                    let (d2, carry) = adc(d2, $modulus.0[2] & borrow, carry);
-                    let (d3, _) = adc(d3, $modulus.0[3] & borrow, carry);
-
-                    $field([d0, d1, d2, d3])
+                    Self::montgomery_form(val, $r2)
                 }
                 #[cfg(not(feature = "asm"))]
                 {

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -63,7 +63,7 @@ macro_rules! field_common {
                 $crate::ff_ext::jacobi::jacobi::<5>(&self.0, &$modulus.0)
             }
 
-            pub const fn montgomery_form(val: [u64; 4], r: $field) -> $field {
+            const fn montgomery_form(val: [u64; 4], r: $field) -> $field {
                 // Converts a 4 64-bit limb value into its congruent field representation.
                 // If `val` representes a 256 bit value then `r` should be R^2,
                 // if `val` represents the 256 MSB of a 512 bit value, then `r` should be R^3.


### PR DESCRIPTION
The functions `from_raw` and `from_u512` convert 256 and 512 bit values into their congruent field elements in Montgomery form.
In order to do this, the values are multiplied by the Montgomery constants `R2` and `R3` appropriately and then reduced.
Hosever, the values of `R2`  and `R3` may lie outside the acceptable bounds used in the asm optimized implementation. 
For this reason, we use an unrolled version of the multiplication and reduction algorithm when the `asm` feature is enabled.


This PR adds the aforementioned unrolled version for `from_u512` to fix the issue. It also adds the test that was used to find the bug.

Tested using:
`cargo nextest run --no-capture -E 'test(test_hash_to_curve_print)' --features "asm"`

Replaces (#103).
Closes (#100).
