### PR TITLE
chore: Bump to 0.5.0 for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Privacy Scaling Explorations team"]
 license = "MIT/Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Bumping up a new release for halo2curves.

CHANGELOG:
## What's Changed
* Add field conversion to/from `[u64;4]` by @jonathanpwang in https://github.com/privacy-scaling-explorations/halo2curves/pull/80
* Compute Legendre symbol for `hash_to_curve` by @davidnevadoc in https://github.com/privacy-scaling-explorations/halo2curves/pull/77
* Add simplified SWU method by @davidnevadoc in https://github.com/privacy-scaling-explorations/halo2curves/pull/81
* Bring back curve algorithms for `a = 0` by @han0110 in https://github.com/privacy-scaling-explorations/halo2curves/pull/82
* fix: Improve serialization for prime fields by @huitseeker in https://github.com/privacy-scaling-explorations/halo2curves/pull/85
* refactor: (De)Serialization of points using `GroupEncoding` by @huitseeker in https://github.com/privacy-scaling-explorations/halo2curves/pull/88
* Insert MSM and FFT code and their benchmarks. by @einar-taiko in https://github.com/privacy-scaling-explorations/halo2curves/pull/86
* Re-export also mod `pairing` and remove flag `reexport` to alwasy re-export by @han0110 in https://github.com/privacy-scaling-explorations/halo2curves/pull/93
* fix regression in #93 reexport field benches aren't run by @mratsim in https://github.com/privacy-scaling-explorations/halo2curves/pull/94
* Fast modular inverse - 9.4x acceleration by @mratsim in https://github.com/privacy-scaling-explorations/halo2curves/pull/83
* Fast isSquare / Legendre symbol / Jacobi symbol - 16.8x acceleration by @mratsim in https://github.com/privacy-scaling-explorations/halo2curves/pull/95
* [fix/optimization] `mul_by_3b` special case should be `CURVE_ID == "bn256_g1"` by @jonathanpwang in https://github.com/privacy-scaling-explorations/halo2curves/pull/101
* Fix nits in `bn256`. by @davidnevadoc in https://github.com/privacy-scaling-explorations/halo2curves/pull/99
* Legendre trait now uses accelerated Jacobi by @mratsim in https://github.com/privacy-scaling-explorations/halo2curves/pull/102
* Booth encoding by @kilic in https://github.com/privacy-scaling-explorations/halo2curves/pull/106
* Add Pluto-Eris cycle of curves by @davidnevadoc in https://github.com/privacy-scaling-explorations/halo2curves/pull/98
* chore(src): typo fix by @Pan-chao in https://github.com/privacy-scaling-explorations/halo2curves/pull/111
* Fix asm version of `from_512` by @davidnevadoc in https://github.com/privacy-scaling-explorations/halo2curves/pull/108
* Update MSRV by @davidnevadoc in https://github.com/privacy-scaling-explorations/halo2curves/pull/113