### PR TITLE
Notify multicore<->WASM compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ The implementations were originally ported from [matterlabs/pairing](https://git
 * Various features related to serialization and deserialization of curve points and field elements.
 * Curve-specific optimizations and benchmarking capabilities.
 
+## Controlling parallelism
+
+`halo2curves` currently uses [rayon](https://github.com/rayon-rs/rayon) for parallel
+computation. The `RAYON_NUM_THREADS` environment variable can be used to set the number of
+threads.
+
+You can disable `rayon` by disabling the `"multicore"` feature.
+Warning! halo2curves will lose access to parallelism if you disable the `"multicore"` feature.
+This will significantly degrade performance.
+
+Notice that if the `multicore` feature is active, the library will not compile to any `wasm` target. 
+This is because WASM architectures at the time of writing this still don't handle parallelism properly. 
+See: [Rayon: Usage with WwbAssembly](https://github.com/rayon-rs/rayon#usage-with-webassembly) for more info. 
+
 ## Benchmarks
 
 Benchmarking is supported through the use of Rust's built-in test framework. Benchmarks can be run without assembly optimizations:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ halo2curves = { version = "0.5.0", features = ["derive_serde", "multicore"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # bypass the default "multicore" feature
-halo2curves = { version = "0.5.0", default-features = false, features = ["derive_serde", "multicore"] }
+halo2curves = { version = "0.5.0", default-features = false, features = ["derive_serde"]] }
 ```
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This will significantly degrade performance.
 
 Notice that if the `multicore` feature is active, the library will not compile to any `wasm` target. 
 This is because WASM architectures at the time of writing this still don't handle parallelism properly. 
-See: [Rayon: Usage with WwbAssembly](https://github.com/rayon-rs/rayon#usage-with-webassembly) for more info. 
+See: [Rayon: Usage with WebAssembly](https://github.com/rayon-rs/rayon#usage-with-webassembly) for more info. 
 
 A way to import this library into the project that works this arround (in case you might compile to `wasm`-targets) could be as follows:
 ```toml

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Notice that if the `multicore` feature is active, the library will not compile t
 This is because WASM architectures at the time of writing this still don't handle parallelism properly. 
 See: [Rayon: Usage with WwbAssembly](https://github.com/rayon-rs/rayon#usage-with-webassembly) for more info. 
 
+A way to import this library into the project that works this arround (in case you might compile to `wasm`-targets) could be as follows:
+```toml
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+halo2curves = { version = "0.5.0", features = ["derive_serde", "multicore"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# bypass the default "multicore" feature
+halo2curves = { version = "0.5.0", default-features = false, features = ["derive_serde", "multicore"] }
+```
 ## Benchmarks
 
 Benchmarking is supported through the use of Rust's built-in test framework. Benchmarks can be run without assembly optimizations:

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -1,3 +1,12 @@
+#[cfg(all(
+    feature = "multicore",
+    target_arch = "wasm32",
+    not(target_feature = "atomics")
+))]
+compile_error!(
+    "The multicore feature flag is not supported on wasm32 architectures without atomics"
+);
+
 pub use maybe_rayon::{
     iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
     join, scope, Scope,


### PR DESCRIPTION
This PR mainly includes 2 things:
1. A check (which I'm still not sure about) that will force the compilation to terminate if `multicore` feature is active while we compile to `WASM`.
2. A README section that explains the issue and leaves it clear that these two things can't work (yet) together.

This should close #120 & #116 