### PR TITLE
Bump lib to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Privacy Scaling Explorations team"]
 license = "MIT/Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library provides efficient and flexible implementations of various halo2-fr
 
 The implementations were originally ported from [matterlabs/pairing](https://github.com/matter-labs/pairing/tree/master/src/bn256) and [zkcrypto/bls12-381](https://github.com/zkcrypto/bls12_381), but have been extended and optimized to cover a broader set of curves and use cases. Since its initial release, the library has expanded to include additional curves, along with the following features:
 
-* `secp256k1`, `secp256r1`, and `grumpkin` curves, enhancing its usability across a range of cryptographic protocols.
+* `secp256k1`, `secp256r1`, `pluto`, `eris` and `grumpkin` curves, enhancing its usability across a range of cryptographic protocols.
 * Assembly optimizations leading to significantly improved performance.
 * Various features related to serialization and deserialization of curve points and field elements.
 * Curve-specific optimizations and benchmarking capabilities.
@@ -59,4 +59,4 @@ The library's top-level directories are organized as follows:
 
 * `benches`: Contains benchmarking tests.
 * `script`: Contains utility scripts.
-* `src`: Contains the source code of the library, further subdivided into modules for each supported curve (`bn256`, `grumpkin`, `secp256k1`, `secp256r1`, `pasta`) and additional functionalities (`derive`, `tests`).
+* `src`: Contains the source code of the library, further subdivided into modules for each supported curve (`bn256`, `grumpkin`, `secp256k1`, `secp256r1`, `secq256k1`, `pasta`, `pluto`, `eris`) and additional functionalities (`derive`, `tests`).


### PR DESCRIPTION
## What's Changed
* feat: implement the SSWU hash_to_curve for `secp256k1` by @duguorong009 in https://github.com/privacy-scaling-explorations/halo2curves/pull/110
* Add badges in README.md by @baumstern in https://github.com/privacy-scaling-explorations/halo2curves/pull/119
* change: Move from `maybe_rayon` to `rayon-1.8` by @CPerezz in https://github.com/privacy-scaling-explorations/halo2curves/pull/122
* chore:fix typos by @AdventureSeeker987 in https://github.com/privacy-scaling-explorations/halo2curves/pull/118
* Add FieldBits impl for Secp256r1 & remove `utils` module by @CPerezz in https://github.com/privacy-scaling-explorations/halo2curves/pull/123
* improve: avoid the inversions in `iso_map_secp256k1` by @duguorong009 in https://github.com/privacy-scaling-explorations/halo2curves/pull/124

## New Contributors
* @duguorong009 made their first contribution in https://github.com/privacy-scaling-explorations/halo2curves/pull/110
* @baumstern made their first contribution in https://github.com/privacy-scaling-explorations/halo2curves/pull/119
* @AdventureSeeker987 made their first contribution in https://github.com/privacy-scaling-explorations/halo2curves/pull/118

**Full Changelog**: https://github.com/privacy-scaling-explorations/halo2curves/compare/v0.5.0...v0.6.0