### PR TITLE
Enable `serde` for Pasta in feature `derive_serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default = ["bits"]
 asm = []
 bits = ["ff/bits"]
 bn256-table = []
-derive_serde = ["serde/derive", "serde_arrays", "hex"]
+derive_serde = ["serde/derive", "serde_arrays", "hex", "pasta_curves/serde"]
 print-trace = ["ark-std/print-trace"]
 
 [profile.bench]


### PR DESCRIPTION
Enable `serde` for pasta curves with the feature `derive_serde`.
Closes #132 