### PR TITLE
upgrade subtle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ impls = "1"
 getrandom = { version = "0.2", features = ["js"] }
 
 [dependencies]
-subtle = "2.4"
+subtle = "2.5"
 ff = { version = "0.13.0", default-features = false, features = ["std"] }
 group = "0.13.0"
 pairing = "0.23.0"


### PR DESCRIPTION
This line https://github.com/privacy-scaling-explorations/halo2curves/blob/main/src/ff_ext/mod.rs#L18 actually requires `subtle 2.5`, so I think it makes sense to bump the version here to force users bump too. It happened to us that subtle 2.4.1 was elected and didn't have this feature. subtle 2.5 works.