### PR TITLE
bump: v0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Privacy Scaling Explorations team"]
 license = "MIT/Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## What's Changed
* fix: typos in curve.rs by @Thabokani in https://github.com/privacy-scaling-explorations/halo2curves/pull/128
* Remove some leftovers by @kilic in https://github.com/privacy-scaling-explorations/halo2curves/pull/127
* improve: add some macros to generate big testing suite of curves by @duguorong009 in https://github.com/privacy-scaling-explorations/halo2curves/pull/129
* Enable `serde` for Pasta in feature `derive_serde` by @davidnevadoc in https://github.com/privacy-scaling-explorations/halo2curves/pull/133
* improve: add some macros to generate big testing suite of fields by @duguorong009 in https://github.com/privacy-scaling-explorations/halo2curves/pull/131
* upgrade subtle by @leonardoalt in https://github.com/privacy-scaling-explorations/halo2curves/pull/136

## New Contributors
* @Thabokani made their first contribution in https://github.com/privacy-scaling-explorations/halo2curves/pull/128
* @leonardoalt made their first contribution in https://github.com/privacy-scaling-explorations/halo2curves/pull/136

**Full Changelog**: https://github.com/privacy-scaling-explorations/halo2curves/compare/v0.6.0...v0.6.1