### PR TITLE
feat: MSM skip doubling when window has all zeros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Privacy Scaling Explorations team"]
 license = "MIT/Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Closes https://github.com/privacy-scaling-explorations/halo2curves/issues/150

To be honest I did not have enough time to understand the full implementation of Cyclone MSM. However the principle that if an entire window has all 0 bits, then it can be totally skipped, seems like it can be carried over exactly the same.