### PR TITLE
Fix norm sign in Pluto Fp2

### DIFF
--- a/src/pluto_eris/fields/fp2.rs
+++ b/src/pluto_eris/fields/fp2.rs
@@ -321,7 +321,7 @@ impl Fp2 {
         // norm = self * self.conjugate()
         let t0 = self.c0.square();
         let t1 = self.c1.square() * U_SQUARE;
-        t1 - t0
+        t0 - t1
     }
 }
 


### PR DESCRIPTION
The coordinates for `Fp2` where reversed, hence the result of the norm computation had the wrong sign.