### PR TITLE
Refactoring field serialization

### DIFF
--- a/derive/src/field/mod.rs
+++ b/derive/src/field/mod.rs
@@ -563,7 +563,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
         .iter()
         .map(|input_size| {
             assert!(*input_size >= size);
-            assert!(*input_size <= size*2);
+            assert!(*input_size <= size * 2);
             quote! {
                 impl ff::FromUniformBytes<#input_size> for #field {
                     fn from_uniform_bytes(bytes: &[u8; #input_size]) -> Self {
@@ -571,19 +571,8 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                         wide[..#input_size].copy_from_slice(bytes);
                         let (a0, a1) = wide.split_at(Self::SIZE);
 
-                        let a0: [u64; Self::NUM_LIMBS] = (0..Self::NUM_LIMBS)
-                            .map(|off| u64::from_le_bytes(a0[off * 8..(off + 1) * 8].try_into().unwrap()))
-                            .collect::<Vec<_>>()
-                            .try_into()
-                            .unwrap();
-                        let a0 = #field(a0);
-
-                        let a1: [u64; Self::NUM_LIMBS] = (0..Self::NUM_LIMBS)
-                            .map(|off| u64::from_le_bytes(a1[off * 8..(off + 1) * 8].try_into().unwrap()))
-                            .collect::<Vec<_>>()
-                            .try_into()
-                            .unwrap();
-                        let a1 = #field(a1);
+                        let a0 = #field(u64s_from_bytes(a0.try_into().unwrap()));
+                        let a1 = #field(u64s_from_bytes(a1.try_into().unwrap()));
 
                         // enforce non assembly impl since asm is likely to be optimized for sparse fields
                         a0.mul_const(&Self::R2) + a1.mul_const(&Self::R3)


### PR DESCRIPTION
This PR aims to: 
 1.  Fix the issue with `is_less_than_modulus` (#178)
 2. Improve / Introduce some clarity around `SerdeObject` and `from_raw`. [Still WIP] (#176)

## `is_less_than_modulus` bug.
This issue was solved by simply removing the check from the `SerdeObject` functions: `from_raw_bytes` and `read_raw`.
This change makes the functions virtually identical to their `_unchecked` versions. I believe this is fine, as the design still makes sense for curve points, where there are other checks involved.
I haven't found a way to keep the check while maintaining the purpose of this interface, which is speed. I'm not sure if there is a way of checking if a value in Montgomery-form lies in the appropriate range w/o performing a Montgomery reduction or any other operation of similar cost.

## Simplify `SerdeObject` and `FromUniformBytes`.
I've introduced the utility `u64s_from_bytes`, to facilitate transforming bytes into limbs. It is a minor change but I think it reduces boilerplate and improves readability.

## `from_raw` [WIP]
Still working on a satisfactory solution for this function. Some possibilities are:
 - Remove pasta curves ( would be in line with https://github.com/privacy-scaling-explorations/halo2/pull/377 )
 - Simply document it with an emphasis on the fact that `_raw` here is canonical and not internal representation like in `SerdeObject`.
 
 Other options have been tried ( exposing functionality through new trait, renaming... ) without success. The roots of the problems are: 
 - Can't have `const fn` in traits.
 - Can't keep compatibility with `pasta_curves`  without modifying them.
 