### PR TITLE
feat: expose field limbs directly

### DIFF
--- a/derive/src/field/mod.rs
+++ b/derive/src/field/mod.rs
@@ -214,7 +214,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
 
     let impl_field = quote! {
         #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
-        pub struct #field(pub(crate) [u64; #num_limbs]);
+        pub struct #field(#[doc(hidden)] pub [u64; #num_limbs]);
 
         impl core::fmt::Debug for #field {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
Currently, there is no efficient way to create a field element directly from an array of limbs (which is the underlying structure). Instead, there are several helper methods that either require Montgomery operations, or leverage slices rather than arrays of limbs, `Vec`s, and `try_into`s.

This is a problem particularly when trying to interop with other libraries that already have elements in Montgomery form.