### PR TITLE
No std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Use typos with config file
         uses: crate-ci/typos@master
-        with: 
+        with:
           config: .config/typos.toml
 
   bench:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  no_std:
+    if: github.event.pull_request.draft == false
+    name: no_std-compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature: [default, bn256-table, derive_serde, ""]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+
+      - name: Download no_std target
+        run: rustup target add thumbv7em-none-eabi
+
+      #  Check if build passes on `thumbv7em-none-eabi` no_std target with and without specific features (default, bn256-table and derive_serde)
+      - name: Build
+        # Script that checks if feature is empty or script should be ran with feature
+        run: |
+          if [ -z "${{ matrix.feature }}" ]; then
+            cargo build --release --target thumbv7em-none-eabi --no-default-features
+          else
+            cargo build --release --target thumbv7em-none-eabi --no-default-features --features ${{ matrix.feature }}
+          fi
   compat:
     if: github.event.pull_request.draft == false
     name: Wasm-compatibility

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ rayon = { version = "1.8", default-features = false, optional = true }
 
 [features]
 default = ["bits", "std"]
-asm = ["halo2derive/asm"]
+asm = ["halo2derive/asm", "std"]
 bits = ["ff/bits"]
 bn256-table = []
 derive_serde = ["serde/derive", "serde_arrays", "hex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ plonky2_maybe_rayon = { version = "1.0.0", default-features = false }
 libm = { version = "0.2.11", default-features = false }
 
 serde = { version = "1.0", default-features = false, optional = true }
-serde_arrays = { version = "0.1.0", optional = true }
+serde_arrays = { version = "0.2.0", optional = true }
 rayon = { version = "1.8", default-features = false, optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ bits = ["ff/bits"]
 bn256-table = []
 derive_serde = ["serde/derive", "serde_arrays", "hex"]
 print-trace = ["ark-std/print-trace"]
-std = ["rayon", "halo2derive/std"]
+std = ["rayon", "halo2derive/std", "plonky2_maybe_rayon/parallel"]
 
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ pairing = { version = "0.23.0", default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-lazy_static = { version = "1.4.0", default-features = false }
+lazy_static = { version = "1.4.0", default-features = false, features = [
+    "spin_no_std",
+] }
 num-bigint = { version = "0.4.3", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,15 +54,17 @@ unroll = { version = "0.1.5", default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }
+plonky2_maybe_rayon = { version = "1.0.0", default-features = false }
 
 
 [features]
-default = ["bits", "rayon"]
+default = ["bits", "std"]
 asm = ["halo2derive/asm"]
 bits = ["ff/bits"]
 bn256-table = []
 derive_serde = ["serde/derive", "serde_arrays", "hex"]
 print-trace = ["ark-std/print-trace"]
+std = ["rayon"]
 
 [profile.bench]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ blake2 = { version = "0.10.6", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }
 plonky2_maybe_rayon = { version = "1.0.0", default-features = false }
+libm = { version = "0.2.11", default-features = false }
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0.105"
 rand_chacha = "0.3.1"
 rand_xorshift = "0.3"
 impls = "1"
-rand_core = { version = "0.6", features=["getrandom"]}
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 
 # Added to make sure we are able to build the lib in the CI.
@@ -61,7 +61,7 @@ default = ["bits", "std"]
 asm = ["halo2derive/asm", "std"]
 bits = ["ff/bits"]
 bn256-table = ["std"]
-derive_serde = ["serde/derive", "serde_arrays", "hex"]
+derive_serde = ["serde/derive", "serde_arrays", "hex", "std"]
 print-trace = ["ark-std/print-trace"]
 std = ["rayon", "halo2derive/std", "plonky2_maybe_rayon/parallel"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,8 @@ bits = ["ff/bits"]
 bn256-table = []
 derive_serde = ["serde/derive", "serde_arrays", "hex"]
 print-trace = ["ark-std/print-trace"]
-std = ["rayon"]
+std = ["rayon", "halo2derive/std"]
+
 
 [profile.bench]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,11 @@ serde = { version = "1.0", default-features = false, optional = true }
 serde_arrays = { version = "0.2.0", optional = true }
 
 [features]
-default = ["bits", "std"]
+default = ["bits"]
 asm = ["halo2derive/asm", "std"]
 bits = ["ff/bits"]
-bn256-table = ["std"]
-derive_serde = ["serde/derive", "serde_arrays", "hex", "std"]
+bn256-table = []
+derive_serde = ["serde/derive", "serde_arrays", "hex"]
 print-trace = ["ark-std/print-trace"]
 std = ["rayon", "halo2derive/std", "plonky2_maybe_rayon/parallel"]
 
@@ -94,6 +94,7 @@ harness = false
 [[bench]]
 name = "msm"
 harness = false
+required-features = ["std"]
 
 [[bench]]
 name = "pairing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ getrandom = { version = "0.2", features = ["js"] }
 [dependencies]
 halo2derive = { path = "derive", version = "0.1.0", default-features = false }
 subtle = { version = "2.5", default-features = false }
-# ! TODO -> remove STD
 ff = { version = "0.13.0", default-features = false, features = ["std"] }
 group = { version = "0.13.0", default-features = false }
 pairing = { version = "0.23.0", default-features = false }
@@ -44,14 +43,10 @@ num-bigint = { version = "0.4.3", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 paste = { version = "1.0.11", default-features = false }
-serde = { version = "1.0", default-features = false, optional = true }
-serde_arrays = { version = "0.1.0", optional = true }
 hex = { version = "0.4", optional = true, default-features = false, features = [
     "alloc",
     "serde",
 ] }
-# ! This is optional
-rayon = { version = "1.8", default-features = false, optional = true }
 unroll = { version = "0.1.5", default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
@@ -59,6 +54,9 @@ digest = { version = "0.10.7", default-features = false }
 plonky2_maybe_rayon = { version = "1.0.0", default-features = false }
 libm = { version = "0.2.11", default-features = false }
 
+serde = { version = "1.0", default-features = false, optional = true }
+serde_arrays = { version = "0.1.0", optional = true }
+rayon = { version = "1.8", default-features = false, optional = true }
 
 [features]
 default = ["bits", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,13 @@ rust-version = "1.63.0"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
-rand_xorshift = "0.3"
 ark-std = { version = "0.3" }
 bincode = "1.3.3"
 serde_json = "1.0.105"
-hex = "0.4"
 rand_chacha = "0.3.1"
+rand_xorshift = "0.3"
 impls = "1"
-rand = { version = "0.8" }
-# getrandom = { version = "0.3.2" }
+rand_core = { version = "0.6", features=["getrandom"]}
 
 
 # Added to make sure we are able to build the lib in the CI.
@@ -29,12 +27,12 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [dependencies]
 halo2derive = { path = "derive", version = "0.1.0", default-features = false }
-subtle = { version = "2.5", default-features = false }
 ff = { version = "0.13.0", default-features = false, features = ["std"] }
 group = { version = "0.13.0", default-features = false }
 pairing = { version = "0.23.0", default-features = false }
+subtle = { version = "2.5", default-features = false }
+
 static_assertions = { version = "1.1.0", default-features = false }
-rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false, features = [
     "spin_no_std",
@@ -47,16 +45,16 @@ hex = { version = "0.4", optional = true, default-features = false, features = [
     "alloc",
     "serde",
 ] }
-unroll = { version = "0.1.5", default-features = false }
-blake2 = { version = "0.10.6", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }
+
 plonky2_maybe_rayon = { version = "1.0.0", default-features = false }
+rayon = { version = "1.8", default-features = false, optional = true }
+
 libm = { version = "0.2.11", default-features = false }
 
 serde = { version = "1.0", default-features = false, optional = true }
 serde_arrays = { version = "0.2.0", optional = true }
-rayon = { version = "1.8", default-features = false, optional = true }
 
 [features]
 default = ["bits", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde_arrays = { version = "0.2.0", optional = true }
 default = ["bits", "std"]
 asm = ["halo2derive/asm", "std"]
 bits = ["ff/bits"]
-bn256-table = []
+bn256-table = ["std"]
 derive_serde = ["serde/derive", "serde_arrays", "hex"]
 print-trace = ["ark-std/print-trace"]
 std = ["rayon", "halo2derive/std", "plonky2_maybe_rayon/parallel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ serde_json = "1.0.105"
 hex = "0.4"
 rand_chacha = "0.3.1"
 impls = "1"
+rand = { version = "0.8" }
+# getrandom = { version = "0.3.2" }
+
 
 # Added to make sure we are able to build the lib in the CI.
 # Notice this will never be loaded for someone using this lib as dep.
@@ -25,30 +28,36 @@ impls = "1"
 getrandom = { version = "0.2", features = ["js"] }
 
 [dependencies]
-halo2derive = {path = "derive", version="0.1.0"}
-subtle = "2.5"
+halo2derive = { path = "derive", version = "0.1.0", default-features = false }
+subtle = { version = "2.5", default-features = false }
+# ! TODO -> remove STD
 ff = { version = "0.13.0", default-features = false, features = ["std"] }
-group = "0.13.0"
-pairing = "0.23.0"
-static_assertions = "1.1.0"
-rand = "0.8"
+group = { version = "0.13.0", default-features = false }
+pairing = { version = "0.23.0", default-features = false }
+static_assertions = { version = "1.1.0", default-features = false }
+rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-lazy_static = "1.4.0"
-num-bigint = "0.4.3"
-num-integer = "0.1.46"
-num-traits = "0.2"
-paste = "1.0.11"
+lazy_static = { version = "1.4.0", default-features = false }
+num-bigint = { version = "0.4.3", default-features = false }
+num-integer = { version = "0.1.46", default-features = false }
+num-traits = { version = "0.2", default-features = false }
+paste = { version = "1.0.11", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_arrays = { version = "0.1.0", optional = true }
-hex = { version = "0.4", optional = true, default-features = false, features = ["alloc", "serde"] }
-rayon = "1.8"
-unroll = "0.1.5"
-blake2 = "0.10.6"
-sha2 = "0.10.8"
-digest = "0.10.7"
+hex = { version = "0.4", optional = true, default-features = false, features = [
+    "alloc",
+    "serde",
+] }
+# ! This is optional
+rayon = { version = "1.8", default-features = false, optional = true }
+unroll = { version = "0.1.5", default-features = false }
+blake2 = { version = "0.10.6", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
+digest = { version = "0.10.7", default-features = false }
+
 
 [features]
-default = ["bits"]
+default = ["bits", "rayon"]
 asm = ["halo2derive/asm"]
 bits = ["ff/bits"]
 bn256-table = []

--- a/benches/curve.rs
+++ b/benches/curve.rs
@@ -9,7 +9,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughpu
 use ff::Field;
 use group::prime::PrimeCurveAffine;
 use halo2curves::{bn256::G1, CurveExt};
-use rand::SeedableRng;
+use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
 fn bench_curve_ops<G: CurveExt>(c: &mut Criterion, name: &'static str) {

--- a/benches/fft.rs
+++ b/benches/fft.rs
@@ -18,7 +18,7 @@ use std::{ops::Range, time::SystemTime};
 use criterion::{BenchmarkId, Criterion};
 use group::ff::Field;
 use halo2curves::{bn256::Fr as Scalar, fft::best_fft};
-use rand::{RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 const RANGE: Range<u32> = 3..19;

--- a/benches/field_arith.rs
+++ b/benches/field_arith.rs
@@ -11,7 +11,7 @@ use halo2curves::{
     ff::Field,
     ff_ext::Legendre,
 };
-use rand::{RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 const SEED: [u8; 16] = [

--- a/benches/hash_to_curve.rs
+++ b/benches/hash_to_curve.rs
@@ -9,8 +9,7 @@ use std::iter;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use halo2curves::{bn256::G1, CurveExt};
-use rand::SeedableRng;
-use rand_core::RngCore;
+use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 const SEED: [u8; 16] = [

--- a/benches/hash_to_curve.rs
+++ b/benches/hash_to_curve.rs
@@ -5,7 +5,7 @@
 //!
 //!     cargo bench --bench hash_to_curve
 
-use std::iter;
+use core::iter;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use halo2curves::{bn256::G1, CurveExt};

--- a/benches/pairing.rs
+++ b/benches/pairing.rs
@@ -10,7 +10,7 @@ use ff::Field;
 use group::prime::PrimeCurveAffine;
 use halo2curves::bn256::Bn256;
 use pairing::Engine;
-use rand::SeedableRng;
+use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
 const SEED: [u8; 16] = [

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -12,13 +12,15 @@ rust-version = "1.63.0"
 proc-macro = true
 
 [dependencies]
-num-bigint = "0.4"
-num-integer = "0.1"
-num-traits = "0.2"
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = {version = "1.0", features = ["full"]}
+num-bigint = { version = "0.4", default-features = false }
+num-integer = { version = "0.1", default-features = false }
+num-traits = { version = "0.2", default-features = false }
+proc-macro2 = { version = "1.0", default-features = false }
+quote = { version = "1.0", default-features = false }
+syn = { version = "1.0", features = ["full"] }
+
 
 [features]
-default = []
+default = ["std"]
 asm = []
+std = []

--- a/derive/src/field/arith.rs
+++ b/derive/src/field/arith.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use proc_macro2::TokenStream;
 use quote::{format_ident as fmtid, quote};
 

--- a/derive/src/field/asm/limb4.rs
+++ b/derive/src/field/asm/limb4.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 
 pub(crate) fn impl_arith(field: &syn::Ident, inv: u64) -> TokenStream {
     quote::quote! {
-        use std::arch::asm;
+        use core::arch::asm;
         impl #field {
             /// Doubles this field element.
             #[inline]

--- a/derive/src/field/mod.rs
+++ b/derive/src/field/mod.rs
@@ -511,6 +511,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 Self::is_less_than_modulus(&elt.0).then(|| elt)
             }
 
+            #[cfg(feature = "std")]
             fn to_raw_bytes(&self) -> Vec<u8> {
                 let mut res = Vec::with_capacity(#num_limbs * 4);
                 for limb in self.0.iter() {

--- a/derive/src/field/mod.rs
+++ b/derive/src/field/mod.rs
@@ -2,6 +2,15 @@ mod arith;
 #[cfg(feature = "asm")]
 mod asm;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::{Num, One};
@@ -510,7 +519,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 res
             }
 
-            #[cfg(features="std")]
+            // #[cfg(features="std")]
             fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
                 let inner = [(); #num_limbs].map(|_| {
                     let mut buf = [0; 8];
@@ -520,7 +529,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 Self(inner)
             }
 
-            #[cfg(features="std")]
+            // #[cfg(features="std")]
             fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let mut inner = [0u64; #num_limbs];
                 for limb in inner.iter_mut() {
@@ -539,7 +548,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                     })
             }
 
-            #[cfg(features="std")]
+            // #[cfg(features="std")]
             fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 for limb in self.0.iter() {
                     writer.write_all(&limb.to_le_bytes())?;

--- a/derive/src/field/mod.rs
+++ b/derive/src/field/mod.rs
@@ -519,7 +519,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 res
             }
 
-            // #[cfg(features="std")]
+            #[cfg(features="std")]
             fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
                 let inner = [(); #num_limbs].map(|_| {
                     let mut buf = [0; 8];
@@ -529,7 +529,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 Self(inner)
             }
 
-            // #[cfg(features="std")]
+            #[cfg(features="std")]
             fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let mut inner = [0u64; #num_limbs];
                 for limb in inner.iter_mut() {
@@ -548,7 +548,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                     })
             }
 
-            // #[cfg(features="std")]
+            #[cfg(features="std")]
             fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 for limb in self.0.iter() {
                     writer.write_all(&limb.to_le_bytes())?;

--- a/derive/src/field/mod.rs
+++ b/derive/src/field/mod.rs
@@ -519,7 +519,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 res
             }
 
-            #[cfg(features="std")]
+            #[cfg(feature = "std")]
             fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
                 let inner = [(); #num_limbs].map(|_| {
                     let mut buf = [0; 8];
@@ -529,7 +529,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 Self(inner)
             }
 
-            #[cfg(features="std")]
+            #[cfg(feature = "std")]
             fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let mut inner = [0u64; #num_limbs];
                 for limb in inner.iter_mut() {
@@ -548,7 +548,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                     })
             }
 
-            #[cfg(features="std")]
+            #[cfg(feature = "std")]
             fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 for limb in self.0.iter() {
                     writer.write_all(&limb.to_le_bytes())?;

--- a/derive/src/field/mod.rs
+++ b/derive/src/field/mod.rs
@@ -453,7 +453,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 Self::R2 * Self(
                     [v as u64, (v >> 64) as u64]
                         .into_iter()
-                        .chain(std::iter::repeat(0))
+                        .chain(core::iter::repeat(0))
                         .take(Self::NUM_LIMBS)
                         .collect::<Vec<_>>()
                         .try_into()
@@ -510,6 +510,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 res
             }
 
+            #[cfg(features="std")]
             fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
                 let inner = [(); #num_limbs].map(|_| {
                     let mut buf = [0; 8];
@@ -519,6 +520,7 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                 Self(inner)
             }
 
+            #[cfg(features="std")]
             fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let mut inner = [0u64; #num_limbs];
                 for limb in inner.iter_mut() {
@@ -536,6 +538,8 @@ pub(crate) fn impl_field(input: TokenStream) -> TokenStream {
                         )
                     })
             }
+
+            #[cfg(features="std")]
             fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 for limb in self.0.iter() {
                     writer.write_all(&limb.to_le_bytes())?;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod field;
 mod utils;
 

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -1,5 +1,9 @@
-use core::ops::Shl;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
+use core::ops::Shl;
 use num_bigint::BigUint;
 use num_traits::{One, ToPrimitive};
 

--- a/src/bls12381/engine.rs
+++ b/src/bls12381/engine.rs
@@ -12,7 +12,7 @@ use core::{
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Group};
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine};
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::{fq12::Fq12, fq2::Fq2, Fr, G1Affine, G2Affine, BLS_X, G1, G2};

--- a/src/bls12381/engine.rs
+++ b/src/bls12381/engine.rs
@@ -1,9 +1,13 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::{
     borrow::Borrow,
     iter::Sum,
-    ops::{Add, Mul, Neg, Sub},
+    ops::{Add, Mul, MulAssign, Neg, Sub},
 };
-use std::ops::MulAssign;
 
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Group};

--- a/src/bls12381/fq.rs
+++ b/src/bls12381/fq.rs
@@ -1,5 +1,9 @@
-use core::convert::TryInto;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
+use core::convert::TryInto;
 use halo2derive::impl_field;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};

--- a/src/bls12381/fq.rs
+++ b/src/bls12381/fq.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use core::convert::TryInto;
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 impl_field!(

--- a/src/bls12381/fq12.rs
+++ b/src/bls12381/fq12.rs
@@ -271,7 +271,7 @@ mod test {
             paste::paste! {
             #[test]
             fn [< $test test >]() {
-                use rand::SeedableRng;
+                use rand_core::SeedableRng;
                 use rand_xorshift::XorShiftRng;
                 let mut rng = XorShiftRng::from_seed(crate::tests::SEED);
                 crate::bls12381::fq12::test::$test(&mut rng, $size);
@@ -280,7 +280,7 @@ mod test {
         };
     }
     use ff::Field;
-    use rand::RngCore;
+    use rand_core::RngCore;
 
     use super::*;
     use crate::{arith_test, frobenius_test, setup_f12_test_funcs, test};

--- a/src/bls12381/fq2.rs
+++ b/src/bls12381/fq2.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::{cmp::Ordering, convert::TryInto};
 use subtle::{Choice, CtOption};
 

--- a/src/bls12381/fq2.rs
+++ b/src/bls12381/fq2.rs
@@ -1,8 +1,3 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 use core::{cmp::Ordering, convert::TryInto};
 use subtle::{Choice, CtOption};
 

--- a/src/bls12381/fq2.rs
+++ b/src/bls12381/fq2.rs
@@ -1,6 +1,4 @@
-use core::convert::TryInto;
-use std::cmp::Ordering;
-
+use core::{cmp::Ordering, convert::TryInto};
 use subtle::{Choice, CtOption};
 
 use super::fq::Fq;

--- a/src/bls12381/fq6.rs
+++ b/src/bls12381/fq6.rs
@@ -286,7 +286,7 @@ mod test {
             paste::paste! {
             #[test]
             fn [< $test test >]() {
-                use rand::SeedableRng;
+                use rand_core::SeedableRng;
                 use rand_xorshift::XorShiftRng;
                 let mut rng = XorShiftRng::from_seed(crate::tests::SEED);
                 crate::bls12381::fq6::test::$test(&mut rng, $size);

--- a/src/bls12381/fr.rs
+++ b/src/bls12381/fr.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 impl_field!(

--- a/src/bls12381/fr.rs
+++ b/src/bls12381/fr.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::convert::TryInto;
 
 use halo2derive::impl_field;

--- a/src/bls12381/g1.rs
+++ b/src/bls12381/g1.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
 use core::{
     cmp,

--- a/src/bls12381/g1.rs
+++ b/src/bls12381/g1.rs
@@ -185,7 +185,9 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{arithmetic::CurveEndo, serde::SerdeObject, tests::curve::TestH2C};
+    #[cfg(feature = "std")]
+    use crate::serde::SerdeObject;
+    use crate::{arithmetic::CurveEndo, tests::curve::TestH2C};
     crate::curve_testing_suite!(G1);
     crate::curve_testing_suite!(G1, "endo_consistency");
     crate::curve_testing_suite!(G1, "endo");

--- a/src/bls12381/g1.rs
+++ b/src/bls12381/g1.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+
 use core::{
     cmp,
     iter::Sum,

--- a/src/bls12381/g2.rs
+++ b/src/bls12381/g2.rs
@@ -339,7 +339,9 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{arithmetic::CurveEndo, serde::SerdeObject};
+    use crate::arithmetic::CurveEndo;
+    #[cfg(feature = "std")]
+    use crate::serde::SerdeObject;
 
     crate::curve_testing_suite!(G2);
     crate::curve_testing_suite!(G2, "endo_consistency");

--- a/src/bls12381/g2.rs
+++ b/src/bls12381/g2.rs
@@ -10,7 +10,7 @@ use core::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::{

--- a/src/bls12381/g2.rs
+++ b/src/bls12381/g2.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+
 use core::{
     cmp,
     fmt::Debug,

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -1,11 +1,17 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::{
     cmp,
+    convert::TryInto,
     fmt::Debug,
     iter::Sum,
     ops::{Add, Mul, Neg, Sub},
 };
-use std::convert::TryInto;
-
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -161,6 +167,7 @@ fn exp_by_x(g2: &G2) -> G2 {
     let x = super::BN_X;
 
     (0..62).rev().fold(*g2, |mut acc, i| {
+        #[cfg(feature = "std")]
         println!("{}", ((x >> i) & 1) == 1);
 
         acc = acc.double();

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -10,7 +10,7 @@ use core::{
     iter::Sum,
     ops::{Add, Mul, Neg, Sub},
 };
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::{

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -1,9 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
 use core::{
     cmp,

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -269,7 +269,9 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{serde::SerdeObject, tests::curve::TestH2C};
+    #[cfg(feature = "std")]
+    use crate::serde::SerdeObject;
+    use crate::tests::curve::TestH2C;
 
     crate::curve_testing_suite!(G2, "clear_cofactor");
     crate::curve_testing_suite!(G1, G2);

--- a/src/bn256/engine.rs
+++ b/src/bn256/engine.rs
@@ -1,10 +1,13 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::{
     borrow::Borrow,
     iter::Sum,
-    ops::{Add, Mul, Neg, Sub},
+    ops::{Add, Mul, MulAssign, Neg, Sub},
 };
-use std::ops::MulAssign;
-
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine};
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use core::convert::TryInto;
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::ff_ext::ExtField;

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -1,5 +1,9 @@
-use core::convert::TryInto;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
+use core::convert::TryInto;
 use halo2derive::impl_field;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};

--- a/src/bn256/fq12.rs
+++ b/src/bn256/fq12.rs
@@ -199,7 +199,7 @@ mod test {
             paste::paste! {
             #[test]
             fn [< $test test >]() {
-                use rand::SeedableRng;
+                use rand_core::SeedableRng;
                 use rand_xorshift::XorShiftRng;
                 let mut rng = XorShiftRng::from_seed(crate::tests::SEED);
                 crate::bn256::fq12::test::$test(&mut rng, $size);
@@ -208,7 +208,7 @@ mod test {
         };
     }
     use ff::Field;
-    use rand::RngCore;
+    use rand_core::RngCore;
 
     use super::*;
     use crate::{arith_test, frobenius_test, setup_f12_test_funcs, test};

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::{cmp::Ordering, convert::TryInto};
 use subtle::{Choice, CtOption};
 

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -1,8 +1,3 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 use core::{cmp::Ordering, convert::TryInto};
 use subtle::{Choice, CtOption};
 

--- a/src/bn256/fq2.rs
+++ b/src/bn256/fq2.rs
@@ -1,6 +1,4 @@
-use core::convert::TryInto;
-use std::cmp::Ordering;
-
+use core::{cmp::Ordering, convert::TryInto};
 use subtle::{Choice, CtOption};
 
 use super::fq::Fq;

--- a/src/bn256/fq6.rs
+++ b/src/bn256/fq6.rs
@@ -213,7 +213,7 @@ mod test {
             paste::paste! {
             #[test]
             fn [< $test test >]() {
-                use rand::SeedableRng;
+                use rand_core::SeedableRng;
                 use rand_xorshift::XorShiftRng;
                 let mut rng = XorShiftRng::from_seed(crate::tests::SEED);
                 crate::bn256::fq6::test::$test(&mut rng, $size);

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 impl_field!(

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::convert::TryInto;
 
 use halo2derive::impl_field;

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1,6 +1,11 @@
 //! This module contains the `Curve`/`CurveAffine` abstractions that allow us to
 //! write code that generalizes over a pair of groups.
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 use core::ops::{Add, Mul, Sub};
 
 use group::prime::{PrimeCurve, PrimeCurveAffine};

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -1,3 +1,10 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 #[macro_export]
 macro_rules! endo {
     ($name:ident, $field:ident, $params:expr) => {
@@ -637,16 +644,19 @@ macro_rules! new_curve_impl {
                 Self::write_raw(self, &mut res).unwrap();
                 res
             }
+            #[cfg(feature="std")]
             fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
                 let [x, y, z] = [(); 3].map(|_| $base::read_raw_unchecked(reader));
                 Self { x, y, z }
             }
+            #[cfg(feature="std")]
             fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let x = $base::read_raw(reader)?;
                 let y = $base::read_raw(reader)?;
                 let z = $base::read_raw(reader)?;
                 Ok(Self { x, y, z })
             }
+            #[cfg(feature="std")]
             fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 self.x.write_raw(writer)?;
                 self.y.write_raw(writer)?;
@@ -666,8 +676,8 @@ macro_rules! new_curve_impl {
 
         // Affine implementations
 
-        impl std::fmt::Debug for $name_affine {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        impl core::fmt::Debug for $name_affine {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
                 if self.is_identity().into() {
                     write!(f, "Infinity")
                 } else {
@@ -738,15 +748,18 @@ macro_rules! new_curve_impl {
                 Self::write_raw(self, &mut res).unwrap();
                 res
             }
+            #[cfg(feature="std")]
             fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
                 let [x, y] = [(); 2].map(|_| $base::read_raw_unchecked(reader));
                 Self { x, y }
             }
+            #[cfg(feature="std")]
             fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let x = $base::read_raw(reader)?;
                 let y = $base::read_raw(reader)?;
                 Ok(Self { x, y })
             }
+            #[cfg(feature="std")]
             fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 self.x.write_raw(writer)?;
                 self.y.write_raw(writer)

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -632,6 +632,8 @@ macro_rules! new_curve_impl {
                     bool::from(res.is_on_curve()).then(|| res)
                 })
             }
+
+            #[cfg(feature = "std")]
             fn to_raw_bytes(&self) -> Vec<u8> {
                 let mut res = Vec::with_capacity(3 * $base::SIZE);
                 Self::write_raw(self, &mut res).unwrap();
@@ -736,23 +738,25 @@ macro_rules! new_curve_impl {
                     bool::from(res.is_on_curve()).then(|| res)
                 })
             }
+
+            #[cfg(feature = "std")]
             fn to_raw_bytes(&self) -> Vec<u8> {
                 let mut res = Vec::with_capacity(2 * $base::SIZE);
                 Self::write_raw(self, &mut res).unwrap();
                 res
             }
-            #[cfg(feature="std")]
+            #[cfg(feature = "std")]
             fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
                 let [x, y] = [(); 2].map(|_| $base::read_raw_unchecked(reader));
                 Self { x, y }
             }
-            #[cfg(feature="std")]
+            #[cfg(feature = "std")]
             fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let x = $base::read_raw(reader)?;
                 let y = $base::read_raw(reader)?;
                 Ok(Self { x, y })
             }
-            #[cfg(feature="std")]
+            #[cfg(feature = "std")]
             fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 self.x.write_raw(writer)?;
                 self.y.write_raw(writer)

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -1,10 +1,3 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 #[macro_export]
 macro_rules! endo {
     ($name:ident, $field:ident, $params:expr) => {

--- a/src/derive/field/common.rs
+++ b/src/derive/field/common.rs
@@ -1,8 +1,3 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 #[macro_export]
 macro_rules! field_bits {
     ($field:ident) => {

--- a/src/derive/field/common.rs
+++ b/src/derive/field/common.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 #[macro_export]
 macro_rules! field_bits {
     ($field:ident) => {
@@ -53,8 +58,8 @@ macro_rules! impl_from_u64 {
     ($field:ident) => {
         impl From<u64> for $field {
             fn from(val: u64) -> $field {
-                let limbs = std::iter::once(val)
-                    .chain(std::iter::repeat(0))
+                let limbs = core::iter::once(val)
+                    .chain(core::iter::repeat(0))
                     .take(Self::NUM_LIMBS)
                     .collect::<Vec<_>>()
                     .try_into()
@@ -71,8 +76,8 @@ macro_rules! impl_from_bool {
     ($field:ident) => {
         impl From<bool> for $field {
             fn from(val: bool) -> $field {
-                let limbs = std::iter::once(u64::from(val))
-                    .chain(std::iter::repeat(0))
+                let limbs = core::iter::once(u64::from(val))
+                    .chain(core::iter::repeat(0))
                     .take(Self::NUM_LIMBS)
                     .collect::<Vec<_>>()
                     .try_into()

--- a/src/derive/field/tower.rs
+++ b/src/derive/field/tower.rs
@@ -1,8 +1,3 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 #[macro_export]
 macro_rules! impl_tower2 {
     (

--- a/src/derive/field/tower.rs
+++ b/src/derive/field/tower.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 #[macro_export]
 macro_rules! impl_tower2 {
     (
@@ -171,15 +176,18 @@ macro_rules! impl_tower2 {
                 }
                 res
             }
+            #[cfg(feature = "std")]
             fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
                 let [c0, c1] = [(); 2].map(|_| $base::read_raw_unchecked(reader));
                 Self { c0, c1 }
             }
+            #[cfg(feature = "std")]
             fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let c0 = $base::read_raw(reader)?;
                 let c1 = $base::read_raw(reader)?;
                 Ok(Self { c0, c1 })
             }
+            #[cfg(feature = "std")]
             fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 self.c0.write_raw(writer)?;
                 self.c1.write_raw(writer)

--- a/src/derive/field/tower.rs
+++ b/src/derive/field/tower.rs
@@ -164,6 +164,8 @@ macro_rules! impl_tower2 {
                     [0, $base::SIZE].map(|i| $base::from_raw_bytes(&bytes[i..i + $base::SIZE]));
                 c0.zip(c1).map(|(c0, c1)| Self { c0, c1 })
             }
+
+            #[cfg(feature = "std")]
             fn to_raw_bytes(&self) -> Vec<u8> {
                 let mut res = Vec::with_capacity($base::SIZE * 2);
                 for limb in self.c0.0.iter().chain(self.c1.0.iter()) {

--- a/src/ff_ext/inverse.rs
+++ b/src/ff_ext/inverse.rs
@@ -1,5 +1,7 @@
-use core::cmp::PartialEq;
-use std::ops::{Add, Mul, Neg, Sub};
+use core::{
+    cmp::PartialEq,
+    ops::{Add, Mul, Neg, Sub},
+};
 
 /// Big signed (B * L)-bit integer type, whose variables store
 /// numbers in the two's complement code as arrays of B-bit chunks.

--- a/src/ff_ext/jacobi.rs
+++ b/src/ff_ext/jacobi.rs
@@ -1,5 +1,7 @@
-use core::cmp::PartialEq;
-use std::ops::{Add, Mul, Neg, Shr, Sub};
+use core::{
+    cmp::PartialEq,
+    ops::{Add, Mul, Neg, Shr, Sub},
+};
 
 /// Big signed (64 * L)-bit integer type, whose variables store
 /// numbers in the two's complement code as arrays of 64-bit chunks.

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -115,10 +115,15 @@ pub fn recursive_butterfly_arithmetic<Scalar: Field, G: FftGroup<Scalar>>(
         a[1] -= &t;
     } else {
         let (left, right) = a.split_at_mut(n / 2);
+        #[cfg(feature = "std")]
         rayon::join(
             || recursive_butterfly_arithmetic(left, n / 2, twiddle_chunk * 2, twiddles),
             || recursive_butterfly_arithmetic(right, n / 2, twiddle_chunk * 2, twiddles),
         );
+        #[cfg(not(feature = "std"))]
+        recursive_butterfly_arithmetic(left, n / 2, twiddle_chunk * 2, twiddles);
+        #[cfg(not(feature = "std"))]
+        recursive_butterfly_arithmetic(right, n / 2, twiddle_chunk * 2, twiddles);
 
         // case when twiddle factor is one
         let (a, left) = left.split_at_mut(1);

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -115,15 +115,10 @@ pub fn recursive_butterfly_arithmetic<Scalar: Field, G: FftGroup<Scalar>>(
         a[1] -= &t;
     } else {
         let (left, right) = a.split_at_mut(n / 2);
-        #[cfg(feature = "std")]
-        rayon::join(
+        plonky2_maybe_rayon::join(
             || recursive_butterfly_arithmetic(left, n / 2, twiddle_chunk * 2, twiddles),
             || recursive_butterfly_arithmetic(right, n / 2, twiddle_chunk * 2, twiddles),
         );
-        #[cfg(not(feature = "std"))]
-        recursive_butterfly_arithmetic(left, n / 2, twiddle_chunk * 2, twiddles);
-        #[cfg(not(feature = "std"))]
-        recursive_butterfly_arithmetic(right, n / 2, twiddle_chunk * 2, twiddles);
 
         // case when twiddle factor is one
         let (a, left) = left.split_at_mut(1);

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -1,7 +1,11 @@
-use ff::Field;
-use group::{GroupOpsOwned, ScalarMulOwned};
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 pub use crate::{CurveAffine, CurveExt};
+use ff::Field;
+use group::{GroupOpsOwned, ScalarMulOwned};
 
 /// This represents an element of a group with basic operations that can be
 /// performed. This allows an FFT implementation (for example) to operate
@@ -38,7 +42,11 @@ pub fn best_fft<Scalar: Field, G: FftGroup<Scalar>>(a: &mut [G], omega: Scalar, 
         r
     }
 
+    #[cfg(feature = "std")]
     let threads = rayon::current_num_threads();
+    #[cfg(not(feature = "std"))]
+    let threads = 1;
+
     let log_threads = threads.ilog2();
     let n = a.len();
     assert_eq!(n, 1 << log_n);

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -45,7 +45,7 @@ pub fn best_fft<Scalar: Field, G: FftGroup<Scalar>>(a: &mut [G], omega: Scalar, 
     #[cfg(feature = "std")]
     let threads = rayon::current_num_threads();
     #[cfg(not(feature = "std"))]
-    let threads = 1;
+    let threads: usize = 1;
 
     let log_threads = threads.ilog2();
     let n = a.len();

--- a/src/grumpkin/curve.rs
+++ b/src/grumpkin/curve.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
 use core::{
     cmp,

--- a/src/grumpkin/curve.rs
+++ b/src/grumpkin/curve.rs
@@ -102,6 +102,7 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
+    #[cfg(feature = "std")]
     use crate::serde::SerdeObject;
     crate::curve_testing_suite!(G1);
     crate::curve_testing_suite!(G1, "endo_consistency");

--- a/src/grumpkin/curve.rs
+++ b/src/grumpkin/curve.rs
@@ -10,7 +10,7 @@ use core::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::{

--- a/src/grumpkin/curve.rs
+++ b/src/grumpkin/curve.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+
 use core::{
     cmp,
     fmt::Debug,

--- a/src/hash_to_curve.rs
+++ b/src/hash_to_curve.rs
@@ -1,5 +1,11 @@
 #![allow(clippy::op_ref)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
 use digest::{core_api::BlockSizeUser, Digest};
 use ff::{Field, FromUniformBytes, PrimeField};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -23,7 +29,7 @@ pub struct Iso<C: CurveExt> {
 pub struct Suite<C: CurveExt, D: Digest + BlockSizeUser, const L: usize> {
     domain: Vec<u8>,
     map_to_curve: Box<dyn Fn(C::Base) -> C>,
-    _marker: std::marker::PhantomData<D>,
+    _marker: core::marker::PhantomData<D>,
 }
 
 pub(crate) fn expand_message<D: Digest + BlockSizeUser>(
@@ -124,7 +130,7 @@ where
         Self {
             map_to_curve,
             domain: domain.to_vec(),
-            _marker: std::marker::PhantomData,
+            _marker: core::marker::PhantomData,
         }
     }
 
@@ -379,7 +385,7 @@ where
 #[cfg(test)]
 mod test {
 
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
 
     use sha2::{Sha256, Sha512};
 

--- a/src/hash_to_curve.rs
+++ b/src/hash_to_curve.rs
@@ -3,9 +3,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use digest::{core_api::BlockSizeUser, Digest};
 use ff::{Field, FromUniformBytes, PrimeField};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-#![no_std]
-// #![cfg_attr(not(feature = "std"), no_std)]
+// #![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod arithmetic;
 mod curve;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// #![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 mod arithmetic;
 mod curve;
 pub mod ff_ext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-// #![no_std]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod arithmetic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-// #![no_std]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+// #![cfg_attr(not(feature = "std"), no_std)]
+
 mod arithmetic;
 mod curve;
 pub mod ff_ext;

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -7,10 +7,7 @@ use crate::CurveAffine;
 use core::ops::Neg;
 use ff::{Field, PrimeField};
 use group::Group;
-#[cfg(feature = "std")]
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
-};
+use plonky2_maybe_rayon::*;
 
 const BATCH_SIZE: usize = 64;
 

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -2,6 +2,8 @@
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
+use libm::log;
+pub use num_traits::float::FloatCore;
 
 use crate::CurveAffine;
 use core::ops::Neg;
@@ -342,7 +344,7 @@ pub fn msm_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C], acc: &mut C
     } else if bases.len() < 32 {
         3
     } else {
-        (f64::from(bases.len() as u32)).ln().ceil() as usize
+        log(f64::from(bases.len() as u32)).ceil() as usize
     };
 
     let field_byte_size = C::Scalar::NUM_BITS.div_ceil(8u32) as usize;
@@ -473,7 +475,7 @@ pub fn msm_best<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
     } else if bases.len() < 32 {
         3
     } else {
-        (f64::from(bases.len() as u32)).ln().ceil() as usize
+        log(f64::from(bases.len() as u32)).ceil() as usize
     };
 
     #[cfg(feature = "std")]

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -547,17 +547,20 @@ pub fn msm_best<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
 
 #[cfg(test)]
 mod test {
-    use std::ops::Neg;
-
-    use ark_std::{end_timer, start_timer};
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+    use core::ops::Neg;
     use ff::{Field, PrimeField};
     use group::{Curve, Group};
     use rand_core::OsRng;
 
-    use crate::{
-        bn256::{Fr, G1Affine, G1},
-        CurveAffine,
-    };
+    use crate::bn256::{Fr, G1Affine, G1};
+    #[cfg(feature = "std")]
+    use crate::CurveAffine;
+    #[cfg(feature = "std")]
+    use ark_std::{end_timer, start_timer};
 
     #[test]
     fn test_booth_encoding() {
@@ -605,8 +608,9 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     fn run_msm_cross<C: CurveAffine>(min_k: usize, max_k: usize) {
-        use rayon::iter::{IntoParallelIterator, ParallelIterator};
+        use plonky2_maybe_rayon::*;
 
         let points = (0..1 << max_k)
             .into_par_iter()
@@ -637,6 +641,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_msm_cross() {
         run_msm_cross::<G1Affine>(14, 18);
     }

--- a/src/pasta/curve.rs
+++ b/src/pasta/curve.rs
@@ -1,5 +1,4 @@
-use std::convert::TryInto;
-
+use core::convert::TryInto;
 use ff::{PrimeField, WithSmallOrderMulGroup};
 
 use super::{fp::Fp, fq::Fq, Pallas, Vesta};

--- a/src/pasta/fp.rs
+++ b/src/pasta/fp.rs
@@ -1,5 +1,9 @@
-use std::convert::TryInto;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
+use core::convert::TryInto;
 use halo2derive::impl_field;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};

--- a/src/pasta/fp.rs
+++ b/src/pasta/fp.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use core::convert::TryInto;
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::{

--- a/src/pasta/fq.rs
+++ b/src/pasta/fq.rs
@@ -1,5 +1,9 @@
-use std::convert::TryInto;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
+use core::convert::TryInto;
 use halo2derive::impl_field;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};

--- a/src/pasta/fq.rs
+++ b/src/pasta/fq.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use core::convert::TryInto;
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::{

--- a/src/pasta/pallas.rs
+++ b/src/pasta/pallas.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
 use core::{
     cmp,

--- a/src/pasta/pallas.rs
+++ b/src/pasta/pallas.rs
@@ -77,7 +77,9 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{curve_testing_suite, serde::SerdeObject};
+    use crate::curve_testing_suite;
+    #[cfg(feature = "std")]
+    use crate::serde::SerdeObject;
 
     curve_testing_suite!(
         Pallas,

--- a/src/pasta/pallas.rs
+++ b/src/pasta/pallas.rs
@@ -11,7 +11,7 @@ use core::{
 };
 
 use ff::{Field, PrimeField, WithSmallOrderMulGroup};
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use super::{fp::Fp, fq::Fq};

--- a/src/pasta/pallas.rs
+++ b/src/pasta/pallas.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+
 use core::{
     cmp,
     fmt::Debug,

--- a/src/pasta/vesta.rs
+++ b/src/pasta/vesta.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
 use core::{
     cmp,

--- a/src/pasta/vesta.rs
+++ b/src/pasta/vesta.rs
@@ -11,7 +11,7 @@ use core::{
 };
 
 use ff::{Field, PrimeField, WithSmallOrderMulGroup};
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use super::{fp::Fp, fq::Fq};

--- a/src/pasta/vesta.rs
+++ b/src/pasta/vesta.rs
@@ -77,7 +77,9 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{curve_testing_suite, serde::SerdeObject};
+    use crate::curve_testing_suite;
+    #[cfg(feature = "std")]
+    use crate::serde::SerdeObject;
 
     curve_testing_suite!(
         Vesta,

--- a/src/pasta/vesta.rs
+++ b/src/pasta/vesta.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+
 use core::{
     cmp,
     fmt::Debug,

--- a/src/pluto_eris/curve.rs
+++ b/src/pluto_eris/curve.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::{
     cmp,
     fmt::Debug,

--- a/src/pluto_eris/curve.rs
+++ b/src/pluto_eris/curve.rs
@@ -281,6 +281,7 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
+    #[cfg(feature = "std")]
     use crate::serde::SerdeObject;
 
     crate::curve_testing_suite!(G2, "clear_cofactor");

--- a/src/pluto_eris/curve.rs
+++ b/src/pluto_eris/curve.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
 use core::{
     cmp,

--- a/src/pluto_eris/curve.rs
+++ b/src/pluto_eris/curve.rs
@@ -11,7 +11,7 @@ use core::{
 };
 
 use group::cofactor::CofactorGroup;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use super::{fp::Fp, fp2::Fp2, fq::Fq};

--- a/src/pluto_eris/engine.rs
+++ b/src/pluto_eris/engine.rs
@@ -1,11 +1,15 @@
 #![allow(clippy::suspicious_arithmetic_impl)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::{
     borrow::Borrow,
     iter::Sum,
-    ops::{Add, Mul, Neg, Sub},
+    ops::{Add, Mul, MulAssign, Neg, Sub},
 };
-use std::ops::MulAssign;
 
 use ff::Field;
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine};

--- a/src/pluto_eris/fp.rs
+++ b/src/pluto_eris/fp.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::ff_ext::ExtField;

--- a/src/pluto_eris/fp.rs
+++ b/src/pluto_eris/fp.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::convert::TryInto;
 
 use halo2derive::impl_field;

--- a/src/pluto_eris/fp12.rs
+++ b/src/pluto_eris/fp12.rs
@@ -259,7 +259,7 @@ mod test {
             paste::paste! {
             #[test]
             fn [< $test test >]() {
-                use rand::SeedableRng;
+                use rand_core::SeedableRng;
                 use rand_xorshift::XorShiftRng;
                 let mut rng = XorShiftRng::from_seed(crate::tests::SEED);
                 crate::pluto_eris::fp12::test::$test(&mut rng, $size);
@@ -268,7 +268,7 @@ mod test {
         };
     }
     use ff::Field;
-    use rand::RngCore;
+    use rand_core::RngCore;
 
     use super::*;
     use crate::{arith_test, frobenius_test, setup_f12_test_funcs, test};

--- a/src/pluto_eris/fp2.rs
+++ b/src/pluto_eris/fp2.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::{cmp::Ordering, convert::TryInto};
 
 use subtle::{Choice, CtOption};

--- a/src/pluto_eris/fp2.rs
+++ b/src/pluto_eris/fp2.rs
@@ -135,7 +135,7 @@ mod test {
 
     #[test]
     fn test_fp2_mul_nonresidue() {
-        use rand::SeedableRng;
+        use rand_core::SeedableRng;
         use rand_xorshift::XorShiftRng;
         let mut rng = XorShiftRng::from_seed(crate::tests::SEED);
         for _ in 0..1000 {

--- a/src/pluto_eris/fp2.rs
+++ b/src/pluto_eris/fp2.rs
@@ -1,5 +1,4 @@
-use core::convert::TryInto;
-use std::cmp::Ordering;
+use core::{cmp::Ordering, convert::TryInto};
 
 use subtle::{Choice, CtOption};
 

--- a/src/pluto_eris/fp2.rs
+++ b/src/pluto_eris/fp2.rs
@@ -1,8 +1,3 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 use core::{cmp::Ordering, convert::TryInto};
 
 use subtle::{Choice, CtOption};

--- a/src/pluto_eris/fp6.rs
+++ b/src/pluto_eris/fp6.rs
@@ -262,7 +262,7 @@ mod test {
             paste::paste! {
             #[test]
             fn [< $test test >]() {
-                use rand::SeedableRng;
+                use rand_core::SeedableRng;
                 use rand_xorshift::XorShiftRng;
                 let mut rng = XorShiftRng::from_seed(crate::tests::SEED);
                 crate::pluto_eris::fp6::test::$test(&mut rng, $size);

--- a/src/pluto_eris/fq.rs
+++ b/src/pluto_eris/fq.rs
@@ -1,5 +1,9 @@
-use core::convert::TryInto;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
+use core::convert::TryInto;
 use halo2derive::impl_field;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};

--- a/src/pluto_eris/fq.rs
+++ b/src/pluto_eris/fq.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use core::convert::TryInto;
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 impl_field!(

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
 use core::{
     cmp,

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -231,7 +231,9 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{serde::SerdeObject, tests::curve::TestH2C};
+    #[cfg(feature = "std")]
+    use crate::serde::SerdeObject;
+    use crate::tests::curve::TestH2C;
 
     crate::curve_testing_suite!(Secp256k1);
     crate::curve_testing_suite!(Secp256k1, "endo_consistency");

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 
 use core::{
     cmp,

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 use core::{
     cmp,
     fmt::Debug,

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -10,7 +10,7 @@ use core::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::{

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 impl_field!(

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::convert::TryInto;
 
 use halo2derive::impl_field;

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 impl_field!(

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::convert::TryInto;
 
 use halo2derive::impl_field;

--- a/src/secp256r1/curve.rs
+++ b/src/secp256r1/curve.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
 use core::{
     cmp,

--- a/src/secp256r1/curve.rs
+++ b/src/secp256r1/curve.rs
@@ -118,7 +118,9 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{serde::SerdeObject, tests::curve::TestH2C};
+    #[cfg(feature = "std")]
+    use crate::serde::SerdeObject;
+    use crate::tests::curve::TestH2C;
     crate::curve_testing_suite!(Secp256r1);
     crate::curve_testing_suite!(Secp256r1, "ecdsa_example");
     crate::curve_testing_suite!(

--- a/src/secp256r1/curve.rs
+++ b/src/secp256r1/curve.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 
 use core::{
     cmp,

--- a/src/secp256r1/curve.rs
+++ b/src/secp256r1/curve.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 use core::{
     cmp,
     fmt::Debug,

--- a/src/secp256r1/curve.rs
+++ b/src/secp256r1/curve.rs
@@ -10,7 +10,7 @@ use core::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::{

--- a/src/secp256r1/fp.rs
+++ b/src/secp256r1/fp.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 impl_field!(

--- a/src/secp256r1/fp.rs
+++ b/src/secp256r1/fp.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::convert::TryInto;
 
 use halo2derive::impl_field;

--- a/src/secp256r1/fq.rs
+++ b/src/secp256r1/fq.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 
 use halo2derive::impl_field;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 impl_field!(

--- a/src/secp256r1/fq.rs
+++ b/src/secp256r1/fq.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::convert::TryInto;
 
 use halo2derive::impl_field;

--- a/src/secq256k1/curve.rs
+++ b/src/secq256k1/curve.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
 use core::{
     cmp,

--- a/src/secq256k1/curve.rs
+++ b/src/secq256k1/curve.rs
@@ -84,11 +84,14 @@ impl Secq256k1 {
 
 #[cfg(test)]
 mod test {
+
+    #[cfg(feature = "std")]
+    use crate::serde::SerdeObject;
+
     use group::UncompressedEncoding;
     use rand_core::OsRng;
 
     use super::*;
-    use crate::serde::SerdeObject;
 
     crate::curve_testing_suite!(Secq256k1);
     crate::curve_testing_suite!(Secq256k1, "endo_consistency");

--- a/src/secq256k1/curve.rs
+++ b/src/secq256k1/curve.rs
@@ -10,7 +10,7 @@ use core::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::{

--- a/src/secq256k1/curve.rs
+++ b/src/secq256k1/curve.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+
 use core::{
     cmp,
     fmt::Debug,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,7 +1,8 @@
-use std::{
-    fmt::Debug,
-    io::{self, Read, Write},
-};
+#[cfg(feature = "std")]
+use std::io::{self, Read, Write};
+extern crate alloc;
+use alloc::vec::Vec;
+use core::fmt::Debug;
 
 #[cfg(feature = "derive_serde")]
 use serde::{Deserialize, Serialize};
@@ -54,15 +55,15 @@ impl<const T: usize> AsRef<[u8]> for Repr<T> {
     }
 }
 
-impl<const T: usize> std::ops::Index<std::ops::Range<usize>> for Repr<T> {
+impl<const T: usize> core::ops::Index<core::ops::Range<usize>> for Repr<T> {
     type Output = [u8];
 
-    fn index(&self, range: std::ops::Range<usize>) -> &Self::Output {
+    fn index(&self, range: core::ops::Range<usize>) -> &Self::Output {
         &self.0[range]
     }
 }
 
-impl<const T: usize> std::ops::Index<usize> for Repr<T> {
+impl<const T: usize> core::ops::Index<usize> for Repr<T> {
     type Output = u8;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -70,24 +71,24 @@ impl<const T: usize> std::ops::Index<usize> for Repr<T> {
     }
 }
 
-impl<const T: usize> std::ops::Index<std::ops::RangeTo<usize>> for Repr<T> {
+impl<const T: usize> core::ops::Index<core::ops::RangeTo<usize>> for Repr<T> {
     type Output = [u8];
 
-    fn index(&self, range: std::ops::RangeTo<usize>) -> &Self::Output {
+    fn index(&self, range: core::ops::RangeTo<usize>) -> &Self::Output {
         &self.0[range]
     }
 }
 
-impl<const T: usize> std::ops::Index<std::ops::RangeFrom<usize>> for Repr<T> {
+impl<const T: usize> core::ops::Index<core::ops::RangeFrom<usize>> for Repr<T> {
     type Output = [u8];
 
-    fn index(&self, range: std::ops::RangeFrom<usize>) -> &Self::Output {
+    fn index(&self, range: core::ops::RangeFrom<usize>) -> &Self::Output {
         &self.0[range]
     }
 }
 
-impl<const T: usize> std::ops::IndexMut<std::ops::Range<usize>> for Repr<T> {
-    fn index_mut(&mut self, range: std::ops::Range<usize>) -> &mut Self::Output {
+impl<const T: usize> core::ops::IndexMut<core::ops::Range<usize>> for Repr<T> {
+    fn index_mut(&mut self, range: core::ops::Range<usize>) -> &mut Self::Output {
         &mut self.0[range]
     }
 }
@@ -113,13 +114,18 @@ pub trait SerdeObject: Sized {
     /// valid object. This function should only be used internally when some
     /// machine state cannot be kept in memory (e.g., between runs)
     /// and needs to be reloaded as quickly as possible.
+    #[cfg(feature = "std")]
     fn read_raw_unchecked<R: Read>(reader: &mut R) -> Self;
-    fn read_raw<R: Read>(reader: &mut R) -> io::Result<Self>;
+    #[cfg(feature = "std")]
+    fn read_raw<R: Read>(reader: &mut R) -> alloc::io::Result<Self>;
 
+    #[cfg(feature = "std")]
     fn write_raw<W: Write>(&self, writer: &mut W) -> io::Result<()>;
 }
 
 pub mod endian {
+    extern crate alloc;
+    use alloc::vec::Vec;
 
     pub trait EndianRepr: Sized {
         const ENDIAN: Endian;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,9 +1,5 @@
 #[cfg(feature = "std")]
 use std::io::{self, Read, Write};
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 
 use core::fmt::Debug;
 
@@ -109,6 +105,7 @@ pub trait SerdeObject: Sized {
     fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self;
     fn from_raw_bytes(bytes: &[u8]) -> Option<Self>;
 
+    #[cfg(feature = "std")]
     fn to_raw_bytes(&self) -> Vec<u8>;
 
     /// The purpose of unchecked functions is to read the internal memory

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "std")]
 use std::io::{self, Read, Write};
+#[cfg(not(feature = "std"))]
 extern crate alloc;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
@@ -117,7 +119,7 @@ pub trait SerdeObject: Sized {
     #[cfg(feature = "std")]
     fn read_raw_unchecked<R: Read>(reader: &mut R) -> Self;
     #[cfg(feature = "std")]
-    fn read_raw<R: Read>(reader: &mut R) -> alloc::io::Result<Self>;
+    fn read_raw<R: Read>(reader: &mut R) -> io::Result<Self>;
 
     #[cfg(feature = "std")]
     fn write_raw<W: Write>(&self, writer: &mut W) -> io::Result<()>;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -4,6 +4,7 @@ use std::io::{self, Read, Write};
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+
 use core::fmt::Debug;
 
 #[cfg(feature = "derive_serde")]

--- a/src/tests/curve.rs
+++ b/src/tests/curve.rs
@@ -308,7 +308,7 @@ macro_rules! curve_testing_suite {
             }
         }
 
-        #[cfg(feature = "derive_serde")]
+        #[cfg(all(feature = "derive_serde", feature = "std"))]
         macro_rules! random_serde_test {
             ($c: ident) => {
                 for _ in 0..100 {
@@ -371,6 +371,7 @@ macro_rules! curve_testing_suite {
     };
 
     ($($curve: ident),*, "hash_to_curve") => {
+        #[cfg(feature = "std")]
         macro_rules! hash_to_curve_test {
             ($c: ident) => {
                 let hasher = $c::hash_to_curve("test");
@@ -386,9 +387,12 @@ macro_rules! curve_testing_suite {
         }
 
         #[test]
+        #[cfg(feature = "std")]
         fn test_hash_to_curve() {
             use rand_core::{OsRng, RngCore};
             use std::iter;
+
+
             $(
                 hash_to_curve_test!($curve);
             )*

--- a/src/tests/curve.rs
+++ b/src/tests/curve.rs
@@ -283,6 +283,7 @@ macro_rules! curve_testing_suite {
         }
 
         // TODO Change name
+        #[cfg(feature = "std")]
         macro_rules! random_serialization_test {
             ($c: ident) => {
                 for _ in 0..100 {
@@ -359,6 +360,7 @@ macro_rules! curve_testing_suite {
             )*
         }
 
+        #[cfg(feature = "std")]
         #[test]
         fn test_serialization() {
             $(

--- a/src/tests/field.rs
+++ b/src/tests/field.rs
@@ -19,7 +19,7 @@ macro_rules! test {
     ($mod: ident, $field:ident, $test:ident, $size:expr) => {
         #[test]
         fn $test() {
-            use rand::SeedableRng;
+            use rand_core::SeedableRng;
             use rand_xorshift::XorShiftRng;
 
             use super::*;
@@ -30,7 +30,7 @@ macro_rules! test {
     ($mod: ident, $field:ident, $test:ident) => {
         #[test]
         fn $test() {
-            use rand::SeedableRng;
+            use rand_core::SeedableRng;
             use rand_xorshift::XorShiftRng;
             let mut rng = XorShiftRng::from_seed($crate::tests::SEED);
             $crate::tests::field::$mod::$test::<$field>(&mut rng);

--- a/src/tests/field/arith.rs
+++ b/src/tests/field/arith.rs
@@ -1,5 +1,5 @@
 use ff::Field;
-use rand::RngCore;
+use rand_core::RngCore;
 
 pub(crate) fn mul_test<F: Field>(mut rng: impl RngCore, n: usize) {
     for _ in 0..n {

--- a/src/tests/field/extensions.rs
+++ b/src/tests/field/extensions.rs
@@ -197,7 +197,7 @@ macro_rules! frobenius_test {
 
         #[test]
         fn frobenius_test() {
-            use rand::SeedableRng;
+            use rand_core::SeedableRng;
             use rand_xorshift::XorShiftRng;
             let mut rng = XorShiftRng::from_seed($crate::tests::SEED);
             test_frobenius(&mut rng, $size);

--- a/src/tests/field/legendre.rs
+++ b/src/tests/field/legendre.rs
@@ -1,5 +1,5 @@
 use ff::PrimeField;
-use rand::RngCore;
+use rand_core::RngCore;
 
 use crate::ff_ext::Legendre;
 

--- a/src/tests/field/serde.rs
+++ b/src/tests/field/serde.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use ff::{Field, FromUniformBytes, PrimeField};
-use rand::RngCore;
+use rand_core::RngCore;
 
 use crate::serde::SerdeObject;
 
@@ -116,7 +116,7 @@ macro_rules! from_uniform_bytes_test {
         paste::paste! {
         #[test]
         fn [< from_uniform_bytes_test_ $L>]() {
-            use rand::SeedableRng;
+            use rand_core::SeedableRng;
             use rand_xorshift::XorShiftRng;
             let mut rng = XorShiftRng::from_seed($crate::tests::SEED);
             $crate::tests::field::serde::from_uniform_bytes_test::<$field, $L>(&mut rng, $size);

--- a/src/tests/field/serde.rs
+++ b/src/tests/field/serde.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use ff::{Field, FromUniformBytes, PrimeField};
 use rand::RngCore;
 

--- a/src/tests/field/serde.rs
+++ b/src/tests/field/serde.rs
@@ -1,12 +1,9 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
-use ff::{Field, FromUniformBytes, PrimeField};
-use rand_core::RngCore;
-
+#[cfg(feature = "std")]
 use crate::serde::SerdeObject;
+#[cfg(any(feature = "std", feature = "derive_serde"))]
+use ff::Field;
+use ff::{FromUniformBytes, PrimeField};
+use rand_core::RngCore;
 
 // Tests to_repr/ from_repr
 pub(crate) fn from_to_repr_test<F: PrimeField>(mut rng: impl RngCore, n: usize) {
@@ -20,6 +17,7 @@ pub(crate) fn from_to_repr_test<F: PrimeField>(mut rng: impl RngCore, n: usize) 
 }
 
 // Tests to_raw_bytes / from_raw_bytes + read_raw /write_raw
+#[cfg(feature = "std")]
 pub(crate) fn from_to_raw_bytes_test<F: Field + SerdeObject>(mut rng: impl RngCore, n: usize) {
     for _ in 0..n {
         let a = F::random(&mut rng);
@@ -41,18 +39,38 @@ where
     for<'de> F: Field + serde::Serialize + serde::Deserialize<'de>,
 {
     for _ in 0..n {
-        // byte serialization
         let a = F::random(&mut rng);
-        let bytes = bincode::serialize(&a).unwrap();
-        let reader = std::io::Cursor::new(bytes);
-        let b = bincode::deserialize_from(reader).unwrap();
-        assert_eq!(a, b);
 
-        // json serialization
+        // Byte serialization
+        let bytes = bincode::serialize(&a).unwrap();
+
+        #[cfg(feature = "std")]
+        {
+            // std version uses Cursor
+            let reader = std::io::Cursor::new(bytes);
+            let b = bincode::deserialize_from(reader).unwrap();
+            assert_eq!(a, b);
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            // no_std version uses slice directly
+            let b = bincode::deserialize(&bytes).unwrap();
+            assert_eq!(a, b);
+        }
+
+        // JSON serialization
         let json = serde_json::to_string(&a).unwrap();
-        let reader = std::io::Cursor::new(json);
-        let b: F = serde_json::from_reader(reader).unwrap();
-        assert_eq!(a, b);
+        #[cfg(feature = "std")]
+        {
+            let reader = std::io::Cursor::new(json);
+            let b: F = serde_json::from_reader(reader).unwrap();
+            assert_eq!(a, b);
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            let b: F = serde_json::from_str(&json).unwrap();
+            assert_eq!(a, b);
+        }
     }
 }
 
@@ -72,6 +90,7 @@ pub(crate) fn test_bits<F: ff::PrimeFieldBits>(mut rng: impl RngCore, n: usize) 
 macro_rules! serde_test {
     ($field:ident) => {
         test!(serde, $field, from_to_repr_test, 100_000);
+        #[cfg(feature = "std")]
         test!(serde, $field, from_to_raw_bytes_test, 100_000);
         #[cfg(feature = "derive_serde")]
         test!(serde, $field, derive_serde_test, 100_000);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use ff::PrimeField;
 use num_bigint::BigUint;
 
@@ -18,7 +23,7 @@ pub(crate) fn hex_to_bytes(hex: &str) -> Vec<u8> {
     let bytes = hex.as_bytes().to_vec();
     bytes
         .chunks(2)
-        .map(|chunk| u8::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16).unwrap())
+        .map(|chunk| u8::from_str_radix(core::str::from_utf8(chunk).unwrap(), 16).unwrap())
         .collect()
 }
 

--- a/src/tests/pairing.rs
+++ b/src/tests/pairing.rs
@@ -1,8 +1,3 @@
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 #[macro_export]
 macro_rules! test_pairing {
     (
@@ -121,6 +116,11 @@ macro_rules! test_pairing {
 
         #[test]
         fn test_pairing_check() {
+            #[cfg(not(feature = "std"))]
+            extern crate alloc;
+            #[cfg(not(feature = "std"))]
+            use alloc::vec::Vec;
+
             let n = 10;
             let g1 = $g1::generator().to_affine();
             let g2 = $g2::generator().to_affine();

--- a/src/tests/pairing.rs
+++ b/src/tests/pairing.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 #[macro_export]
 macro_rules! test_pairing {
     (


### PR DESCRIPTION
# No_std support for halo2curves. 

## Default functionality will stay the same. 

Closes -> #191 

### Most important changes -> 

When using halo2curves with `default-features = false` , parallelization will be turned off with `plonky2_maybe_rayon` as parallelization is operating system dependent feature. Another notable thing is that in `no_std` 4 functions of `SerdeObject` trait won't be available -> 

```diff


/// Trait for converting raw bytes to/from the internal representation of a
/// type. For example, field elements are represented in Montgomery form and
/// serialized/deserialized without Montgomery reduction.
pub trait SerdeObject: Sized {
    /// The purpose of unchecked functions is to read the internal memory
    /// representation of a type from bytes as quickly as possible. No
    /// sanitization checks are performed to ensure the bytes represent a
    /// valid object. As such this function should only be used internally
    /// as an extension of machine memory. It should not be used to deserialize
    /// externally provided data.
    fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self;
    fn from_raw_bytes(bytes: &[u8]) -> Option<Self>;

+   #[cfg(feature = "std")]
    fn to_raw_bytes(&self) -> Vec<u8>;

    /// The purpose of unchecked functions is to read the internal memory
    /// representation of a type from disk as quickly as possible. No
    /// sanitization checks are performed to ensure the bytes represent a
    /// valid object. This function should only be used internally when some
    /// machine state cannot be kept in memory (e.g., between runs)
    /// and needs to be reloaded as quickly as possible.
+   #[cfg(feature = "std")]
    fn read_raw_unchecked<R: Read>(reader: &mut R) -> Self;
+   #[cfg(feature = "std")]
    fn read_raw<R: Read>(reader: &mut R) -> io::Result<Self>;

+   #[cfg(feature = "std")]
    fn write_raw<W: Write>(&self, writer: &mut W) -> io::Result<()>;
}

```

`read_raw_unchecked()` , `read_raw()`  and `write_raw()` functions can not be used due to the `std::io::Read` and `std::io::Write` traits. 

I had to put a `std` feature flag on `to_raw_bytes()` too, because of https://github.com/privacy-scaling-explorations/halo2curves/pull/192/files#diff-a8cb01ec1b5a3d6c72d164a54bdf6a06049e53be96cb2d9be434618d5a8fec15R636 . 
`to_raw_bytes()` is calling `write_raw()` function that is behing `std` feature flag.

It is possible to "unlock" those 4 methods in `no_std` environment too, but then method signature would have to be changed. `to_raw_bytes` could be unlocked anyway, but then different implementation (the one that doesn't call `write_raw()`) should be used.


Everything else is pretty straight forward. Using `alloc` and `core` when `std` feature is off. Dependencies are used with `default-features = false` .

------

As I said, **default functionality remains unchanged**, but this gives users an option to use the library in a no_std environments too by disabling default features. Also, **all tests are passing**!
To build the halo2curves library on `no_std` target, use `cargo build --target thumbv7em-none-eabi --no-default-features` .

I’m more than open to all questions, suggestions, discussions, and corrections! Please let me know what you think and if you need anything else! Thank you! :)
-----