### PR TITLE
Rename serialization macro for clarity

### DIFF
--- a/src/tests/curve.rs
+++ b/src/tests/curve.rs
@@ -282,8 +282,7 @@ macro_rules! curve_testing_suite {
             }
         }
 
-        // TODO Change name
-        macro_rules! random_serialization_test {
+        macro_rules! raw_serialization_roundtrip_test {
             ($c: ident) => {
                 for _ in 0..100 {
                     let projective_point = $c::random(OsRng);
@@ -362,7 +361,7 @@ macro_rules! curve_testing_suite {
         #[test]
         fn test_serialization() {
             $(
-                random_serialization_test!($curve);
+                raw_serialization_roundtrip_test!($curve);
                 #[cfg(feature = "derive_serde")]
                 random_serde_test!($curve);
             )*


### PR DESCRIPTION
This PR renames the internal macro `random_serialization_test!` to `raw_serialization_roundtrip_test!` to better reflect what it actually does.

### Why

Despite the original name, the macro does not test cryptographic signing/verification — it focuses solely on raw serialization/deserialization of curve points.

This improves readability and avoids misleading implications.
