### PR TITLE
update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         package: [halo2curves]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
             profile: minimal


### PR DESCRIPTION
Updates actions/checkout to the latest stable version v4.

Changes:

Updates all instances of actions/checkout@v3 to actions/checkout@v4

Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.