### PR TITLE
docs: Fix typos and grammatical errors in comments

### DIFF
--- a/benches/hash_to_curve.rs
+++ b/benches/hash_to_curve.rs
@@ -1,4 +1,4 @@
-//! This benchmarks basic the hash-to-curve algorithm.
+//! This benchmarks the basic hash-to-curve algorithm.
 //! It measures `G1` from the BN256 curve.
 //!
 //! To run this benchmark:

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -183,7 +183,7 @@ macro_rules! new_curve_impl {
         }
 
         /// A macro to help define point serialization using the [`group::GroupEncoding`] trait
-        /// This assumes both point types ($name, $nameaffine) implement [`group::GroupEncoding`].
+        /// This assumes both point types ($name, $name_affine) implement [`group::GroupEncoding`].
         #[cfg(feature = "derive_serde")]
         macro_rules! serialize_deserialize_to_from_bytes {
             () => {

--- a/src/ff_ext/mod.rs
+++ b/src/ff_ext/mod.rs
@@ -14,7 +14,7 @@ pub trait Legendre {
 
     #[inline(always)]
     fn ct_quadratic_residue(&self) -> Choice {
-        // The legendre symbol returns 0 for 0
+        // The Legendre symbol returns 0 for 0
         // and 1 for quadratic residues,
         // we consider 0 a square hence quadratic residue.
         self.legendre().ct_ne(&-1)


### PR DESCRIPTION
src/derive/curve.rs: 
- Fixes a typo in a macro comment to correctly reference the `$name_affine` variable, ensuring consistency between the code and its description.

benches/hash_to_curve.rs: 
- Corrects a grammatical error (`basic the` -> `the basic`) in the file's documentation comment.

src/ff_ext/mod.rs: 
- Capitalizes `Legendre symbol` to follow the standard convention for proper nouns in technical documentation.
