### PR TITLE
fix: remove trailing commas in println! macros in benchmark files

### DIFF
--- a/benches/fft.rs
+++ b/benches/fft.rs
@@ -29,7 +29,7 @@ const SEED: [u8; 16] = [
 fn generate_data(k: u32, mut rng: impl RngCore) -> Vec<Scalar> {
     let n = 1 << k;
     let timer = SystemTime::now();
-    println!("\n\nGenerating 2^{k} = {n} values..",);
+    println!("\n\nGenerating 2^{k} = {n} values..");
     let data: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
     let end = timer.elapsed().unwrap();
     println!(

--- a/benches/msm.rs
+++ b/benches/msm.rs
@@ -41,7 +41,7 @@ fn generate_curvepoints(k: u8) -> Vec<Point> {
         1 << k
     };
 
-    println!("Generating 2^{k} = {n} curve points..",);
+    println!("Generating 2^{k} = {n} curve points..");
     let timer = SystemTime::now();
     let bases = (0..n)
         .into_par_iter()
@@ -83,7 +83,7 @@ fn generate_coefficients(k: u8, bits: usize) -> Vec<Scalar> {
         _ => panic!("unexpected bit size {}", bits),
     };
 
-    println!("Generating 2^{k} = {n} coefficients..",);
+    println!("Generating 2^{k} = {n} coefficients..");
     let timer = SystemTime::now();
     let coeffs = (0..n)
         .into_par_iter()


### PR DESCRIPTION
Fixed syntax errors in benchmark files by removing trailing commas in println! macros:

- benches/fft.rs: Removed trailing comma in println! macro on line 30
- benches/msm.rs: Removed trailing commas in println! macros on lines 45 and 75

as println! macros don't accept trailing commas after the last argument.