### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         feature: [default, bn256-table, derive_serde, ""]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
 
       - name: Download no_std target
@@ -67,7 +67,7 @@ jobs:
           - wasm32-unknown-unknown
           - wasm32-wasi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
 
       - name: Download WASM targets
@@ -88,7 +88,7 @@ jobs:
           - feature: derive_serde
           - feature: asm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
       # use the more efficient nextest
       - uses: taiki-e/install-action@nextest
@@ -110,7 +110,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - run: rustup component add rustfmt
@@ -124,7 +124,7 @@ jobs:
     name: Clippy lint checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
@@ -139,7 +139,7 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use typos with config file
         uses: crate-ci/typos@master
         with:
@@ -156,7 +156,7 @@ jobs:
           - feature: asm
           - feature: bn256-table
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - name: Bench arithmetic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         package: [halo2curves]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
             profile: minimal


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5
Reference: https://github.com/actions/checkout/releases/tag/v5.0.0