### PR TITLE
Features for curve modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,13 +57,22 @@ serde = { version = "1.0", default-features = false, optional = true }
 serde_arrays = { version = "0.2.0", optional = true }
 
 [features]
-default = ["bits"]
+default = ["bits", "bn256"]
 asm = ["halo2derive/asm", "std"]
 bits = ["ff/bits"]
 bn256-table = []
 derive_serde = ["serde/derive", "serde_arrays", "hex"]
 print-trace = ["ark-std/print-trace"]
 std = ["rayon", "halo2derive/std", "plonky2_maybe_rayon/parallel"]
+bls12-381 = []
+bn256 = []
+grumpkin = []
+pasta = []
+pluto-eris = []
+secp256k1 = []
+secp256r1 = []
+secq256k1 = []
+t256 = []
 
 
 [profile.bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,31 @@ pub mod hash_to_curve;
 pub mod msm;
 pub mod serde;
 
+#[cfg(feature = "bls12-381")]
 pub mod bls12381;
+
+#[cfg(feature = "bn256")]
 pub mod bn256;
+
+#[cfg(feature = "grumpkin")]
 pub mod grumpkin;
+
+#[cfg(feature = "pasta")]
 pub mod pasta;
+
+#[cfg(feature = "pluto-eris")]
 pub mod pluto_eris;
+
+#[cfg(feature = "secp256k1")]
 pub mod secp256k1;
+
+#[cfg(feature = "secp256r1")]
 pub mod secp256r1;
+
+#[cfg(feature = "secq256k1")]
 pub mod secq256k1;
+
+#[cfg(feature = "t256")]
 pub mod t256;
 
 #[macro_use]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -177,6 +177,7 @@ pub mod endian {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) enum CompressedFlagConfig {
     // NOTE: if needed we can add fields for bit positions
 

--- a/src/t256/curve.rs
+++ b/src/t256/curve.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
 use core::{
     cmp,
@@ -121,7 +121,10 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
+
+    #[cfg(feature = "std")]
     use crate::serde::SerdeObject;
+
     crate::curve_testing_suite!(T256);
     crate::curve_testing_suite!(T256, "ecdsa_example");
     crate::curve_testing_suite!(


### PR DESCRIPTION
# Description 
The library has grown to include implementations for 9 different curves, plus the pasta re-export. As a result, build times have steadily increased with each addition. Since most downstream projects only use a subset of the available curves (typically just the traits and a few specific curve implementations) this PR introduces feature gating for the curve modules. This allows consumers to opt into only the curves they need, significantly reducing build times and improving compile efficiency.

# Changes
 - Features for each curve module.
 - `bn256` added as a default feature.
 - Some minor fixes to `t256` imports.