### PR TITLE
Fixes typos in documentation

### DIFF
--- a/src/curve.rs
+++ b/src/curve.rs
@@ -40,7 +40,7 @@ pub trait CurveExt:
     /// by an element of multiplicative order 3.
     fn endo(&self) -> Self;
 
-    /// Return the Jacobian coordinates of this point.
+    /// Returns the Jacobian coordinates of this point.
     fn jacobian_coordinates(&self) -> (Self::Base, Self::Base, Self::Base);
 
     /// Requests a hasher that accepts messages and returns near-uniformly

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -101,7 +101,7 @@ pub fn best_fft<Scalar: Field, G: FftGroup<Scalar>>(a: &mut [G], omega: Scalar, 
     }
 }
 
-/// This perform recursive butterfly arithmetic
+/// This performs recursive butterfly arithmetic
 pub fn recursive_butterfly_arithmetic<Scalar: Field, G: FftGroup<Scalar>>(
     a: &mut [G],
     n: usize,


### PR DESCRIPTION
Corrects minor grammatical errors in documentation for curve and FFT functionalities, improving readability.