### PR TITLE
fix: enable doc_cfg for docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod arithmetic;
 mod curve;


### PR DESCRIPTION
Fixes #175

I reproduce error from [docs.rs rustdoc build](https://docs.rs/crate/halo2curves/0.8.0/builds/1598587) using:
```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps
```
This now generates documentation successfully.